### PR TITLE
Optionally include /etc/td-agent/conf.d/*.conf files

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -80,6 +80,11 @@ This installs the latest version of +aws-sdk+
       plugin false
     end
 
+== includes
+
+Optionally include /etc/td-agent/conf.d/*.conf files (i.e. symlinks, other recipes, etc.)
+
+- node[:td_agent][:includes] = false
 
 = USAGE:
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,6 @@
 default[:td_agent][:api_key] = ''
 
 default[:td_agent][:plugins] = []
+
+default[:td_agent][:includes] = false
+

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -51,6 +51,12 @@ template "/etc/td-agent/td-agent.conf" do
   source "td-agent.conf.erb"
 end
 
+if node['td_agent']['includes']
+  directory "/etc/td-agent/conf.d" do
+    mode "0644"
+  end
+end
+
 package "td-agent" do
   options value_for_platform(
     ["ubuntu", "debian"] => {"default" => "-f --force-yes"},

--- a/templates/default/td-agent.conf.erb
+++ b/templates/default/td-agent.conf.erb
@@ -1,3 +1,6 @@
+<% if node['td_agent']['includes'] %>
+include conf.d/*.conf 
+<% end %>
 ####
 ## Output descriptions:
 ##


### PR DESCRIPTION
to manage separate conf files using another chef cookbook.
