### PR TITLE
Specify gpgkey

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -42,6 +42,7 @@ when "ubuntu"
 when "centos", "redhat"
   yum_repository "treasure-data" do
     url "http://packages.treasure-data.com/redhat/$basearch"
+    gpgkey "http://packages.treasure-data.com/redhat/RPM-GPG-KEY-td-agent"
     action :add
   end
 end


### PR DESCRIPTION
`yum_repository` resource sets `gpgcheck=1` by default. So cooking failed with the message `Public key for td-libyaml-0.1.4-1.x86_64.rpm is not installed`.

Related: https://github.com/treasure-data/td-agent/issues/43
