### PR TITLE
Specify cookbook's name in metadata.rb.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "td-agent"
 maintainer       "Treasure Data, Inc."
 maintainer_email "k@treasure-data.com"
 license          "All rights reserved"


### PR DESCRIPTION
I added the name of this cookbook to `metadata.rb`.

FYI:
http://acrmp.github.io/foodcritic/#FC045
http://docs.opscode.com/essentials_cookbook_metadata.html
