### PR TITLE
Add option for not using default matchers and sources in td-agent.conf

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -86,6 +86,12 @@ Optionally include /etc/td-agent/conf.d/*.conf files (i.e. symlinks, other recip
 
 - node[:td_agent][:includes] = false
 
+== default_config
+
+Optionally prevent /etc/td-agent/td-agent.conf from including default config.
+
+- node[:td_agent][:default_config] = true
+
 = USAGE:
 
 This is an example role file.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,4 +3,5 @@ default[:td_agent][:api_key] = ''
 default[:td_agent][:plugins] = []
 
 default[:td_agent][:includes] = false
+default[:td_agent][:default_config] = true
 

--- a/templates/default/td-agent.conf.erb
+++ b/templates/default/td-agent.conf.erb
@@ -1,6 +1,7 @@
 <% if node['td_agent']['includes'] %>
 include conf.d/*.conf 
 <% end %>
+<% if node['td_agent']['default_config'] %>
 ####
 ## Output descriptions:
 ##
@@ -56,3 +57,4 @@ include conf.d/*.conf
   bind 127.0.0.1
   port 24230
 </source>
+<% end %>


### PR DESCRIPTION
I am using chef-td-agent but I don't want to use the default
matchers and sources defined in
https://github.com/treasure-data/chef-td-agent/blob/master/templates/default/td-agent.conf.erb

In order to remove them I do something like

```
include_recipe "td-agent"

template "/etc/td-agent/td-agent.conf" do
  mode "0644"
  source "td-agent-without-defaults.conf.erb"
end
```

This is kind of undesirable because everytime I provision a machine
with this recipe, the resource is updated by chef-td-agent and then
by my recipe, which causes td-agent to restart twice (even when there
were no differences in the file in consecutive provisionings).

I would be happy if this could be included in your repo.
