### PR TITLE
made http api an option

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -131,3 +131,11 @@ This is an example role file.
         ]
       }
     )
+
+= HTTP API Options
+
+- node[:td_agent][:http_in][:enable_api] = true. 
+
+Access to the API may be turend off by setting enable_api to false. This may be of particular use when 
+td-agent is being used on endpoint systems that are forwarding logs to a centralized td-agent server.
+

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,7 +4,7 @@ default[:td_agent][:plugins] = []
 
 default[:td_agent][:includes] = false
 default[:td_agent][:default_config] = true
-default[:td_agent][:enable_http_api] = true
+default[:td_agent][:in_http][:enable_api] = true
 default[:td_agent][:version] = '1.1.19'
 default[:td_agent][:pinning_version] = false
 default[:td_agent][:in_forward] = {

--- a/templates/default/td-agent.conf.erb
+++ b/templates/default/td-agent.conf.erb
@@ -43,7 +43,7 @@ include conf.d/*.conf
 #  type unix
 #</source>
 
-<% if node[:td_agent][:enable_http_api] %>
+<% if node[:td_agent][:in_http][:enable_api] %>
 # HTTP input
 # POST http://localhost:8888/<tag>?json=<json>
 # POST http://localhost:8888/td.myapp.login?json={"user"%3A"me"}


### PR DESCRIPTION
The default td-data.conf opens up port 8888 for an http api. This patch makes the api optional.
