### PR TITLE
added gpg key for apt repository

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -37,6 +37,7 @@ when "ubuntu"
     uri source
     distribution dist
     components ["contrib"]
+    key "http://packages.treasure-data.com/debian/RPM-GPG-KEY-td-agent"
     action :add
   end
 when "centos", "redhat"
@@ -59,10 +60,6 @@ if node['td_agent']['includes']
 end
 
 package "td-agent" do
-  options value_for_platform(
-    ["ubuntu", "debian"] => {"default" => "-f --force-yes"},
-    "default" => nil
-    )
   action :upgrade
   version node[:td_agent][:version] if node[:td_agent][:pinning_version]
 end


### PR DESCRIPTION
Isn't it better to just add the gpg key to the apt repository instead of forcing yes on the package install without gpg key?
