### PR TITLE
Add support for platform "amazon" (tested)

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -40,7 +40,7 @@ when "ubuntu"
     key "http://packages.treasure-data.com/debian/RPM-GPG-KEY-td-agent"
     action :add
   end
-when "centos", "redhat"
+when "centos", "redhat", "amazon"
   yum_repository "treasure-data" do
     url "http://packages.treasure-data.com/redhat/$basearch"
     gpgkey "http://packages.treasure-data.com/redhat/RPM-GPG-KEY-td-agent"


### PR DESCRIPTION
in accordance with current maintainer, repeatedly@gmail.com.  
As per issue, Unnecessarily strict platform check #18,
  "We don't have a test environment for Amazon Linux and we don't guarantee td-agent works on Amazon Linux.
  If it is OK, please send a PR :)"
Done.   I have been using and testing the mod in question on amazon, centos, and ubuntu over the past week.

thanks!
