### PR TITLE
Fix pinning version

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -60,8 +60,12 @@ if node['td_agent']['includes']
 end
 
 package "td-agent" do
-  action :install
-  version node[:td_agent][:version] if node[:td_agent][:pinning_version]
+  if node[:td_agent][:pinning_version]
+    action :install
+    version node[:td_agent][:version]
+  else
+    action :upgrade
+  end
 end
 
 node[:td_agent][:plugins].each do |plugin|


### PR DESCRIPTION
When pinning version, an action of package resource should be :install.

http://docs.opscode.com/resource_package.html#actions

| Action | Description |
| --- | --- |
| :install | Default. Use to install a package. If a version is specified, use to install the specified version of a package. |
| :upgrade | Use to install a package and/or to ensure that a package is the latest version. |
