### PR TITLE
modified: /var/run/td-agent 0755

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,6 +25,13 @@ user 'td-agent' do
   action   [:create, :manage]
 end
 
+directory '/var/run/td-agent/' do
+  owner  'td-agent'
+  group  'td-agent'
+  mode   '0755'
+  action :create
+end
+
 directory '/etc/td-agent/' do
   owner  'td-agent'
   group  'td-agent'


### PR DESCRIPTION
Hi, we need 0755 permission in home_dir?
in this case
http://docs.treasuredata.com/articles/php#modifying-etctd-agenttd-agentconf

my env: AWS
httpd: apache (mod_php)
error:
[Thu Sep 11 17:44:16 2014] [error] [client ---.--.---.-] Fluent\Logger\FluentLogger stream_socket_client(): unable to connect to unix:///var/run/td-agent/td-agent.sock (Permission denied) 
