### PR TITLE
Prefix include with '@'

### DIFF
--- a/templates/default/td-agent.conf.erb
+++ b/templates/default/td-agent.conf.erb
@@ -1,5 +1,5 @@
 <% if node['td_agent']['includes'] %>
-include conf.d/*.conf
+@include conf.d/*.conf
 <% end %>
 <% if node['td_agent']['default_config'] %>
 ####

--- a/templates/default/td-agent.conf.erb
+++ b/templates/default/td-agent.conf.erb
@@ -1,5 +1,6 @@
 <% if node['td_agent']['includes'] %>
-@include conf.d/*.conf
+# Use @include for td-agent version > v1.1.20 (fluentd version > v0.10.49)
+include conf.d/*.conf
 <% end %>
 <% if node['td_agent']['default_config'] %>
 ####


### PR DESCRIPTION
According to https://github.com/fluent/fluentd/blob/master/lib%2Ffluent%2Fconfig%2Fv1_parser.rb#L99 update the `include` keyword with prefix `@`

    2014-10-29 07:42:22 +0000 [info]: starting fluentd-0.10.55
    2014-10-29 07:42:22 +0000 [info]: reading config file path="/etc/td-agent/td-agent.conf"
    2014-10-29 07:42:22 +0000 [warn]: 'include' is deprecated. Use '@include' instead