### PR TITLE
Init.d script fixed for rhel family

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -116,6 +116,12 @@ node["td_agent"]["plugins"].each do |plugin|
   end
 end
 
+link '/etc/init.d/td-agent' do
+  to '/opt/td-agent/etc/init.d/td-agent'
+  link_type :symbolic
+  only_if { node.platform_family?('rhel') }
+end
+
 service "td-agent" do
   action [ :enable, :start ]
 end


### PR DESCRIPTION
The td-agent rpm package with version 2 doesn't create init.d script. I fixed in cookbook by creating link from /opt/td-agent/etc/init.d/td-agent to /etc/init.d/td-agent.