### PR TITLE
change platform to platform_family

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -41,8 +41,8 @@ directory '/etc/td-agent/' do
   action :create
 end
 
-case node['platform']
-when "ubuntu"
+case node['platform_family']
+when "debian"
   dist = node['lsb']['codename']
   source =
     if major.nil? || major == '1'
@@ -64,7 +64,7 @@ when "ubuntu"
     key "http://packages.treasuredata.com/GPG-KEY-td-agent"
     action :add
   end
-when "centos", "redhat", "amazon"
+when "rhel"
   source =
     if major.nil? || major == '1'
       "http://packages.treasuredata.com/redhat/$basearch"


### PR DESCRIPTION
This PR change platform to platform_family, this will save time for future refactoring default recipe and add new distributions. For example,  platform_family 'rhel' include centos / amazon / parallels servers and other rhel/rpm based distributes. 
