### PR TITLE
Fix API inconsistencies with Chef 12.3.0

### DIFF
--- a/resources/gem.rb
+++ b/resources/gem.rb
@@ -29,9 +29,13 @@ attribute :gem_binary,     :kind_of => String, :default => ""
 attribute :response_file,  :kind_of => String
 attribute :plugin,         :kind_of => [TrueClass, FalseClass], :default => false
 
-
 def initialize(*args)
   super
   @action = :install
   @provider = Chef::Provider::Package::TdRubygems
 end
+
+def clear_sources(arg=nil)
+  set_or_return(:clear_sources, arg, :kind_of => [ TrueClass, FalseClass ])
+end
+


### PR DESCRIPTION
## Issue summary

Chef 12.3.0 was released on April 28th 2015. In this commit is a small change to the Gem package Resource that adds the attribute `clear_sources` [1]

Running `chef-solo` to provision a new machine in our cluster using the `td-agent` recipe resulted in the following error output [2]. This error can also be seen when running the Kitchen tests against the `td-agent` cookbook - during the `lwrp` suites, on all platforms.

## Cause

The `Chef::Provider::Package::RubyGems` provider is coupled to the implementation of several methods in the `Chef::Resource::GemPackage` resource definition.

The `td-agent` cookbook provides the `TdAgentGem` resource (implemented as a Chef LWRP - `td-agent/providers/gem.rb`). This resource assigns itself a custom package provider (The `Chef::Provider::Package::TdRubyGems` provider, implemented in `/libraries`). 

This provider is a subclass of the `Chef::Provider::Package::Rubygems` provider and the coupling between `Chef::Resource::GemPackage` and `Chef::Provider::Package::RubyGems` results in the `TdAgentGem` LWRP being indirectly coupled to the interface of `Chef::Resource::GemPackage`.

## Solution

This commit adds the new `clear_sources` method into the `TdAgentGem` LWRP to maintain API compatibility between it and the `GemPackage` class it is shadowing.

This is probably not the most ideal solution, as it still relies on API tracking the `GemPackage` resource upstream and will directly break the next time Chef solo gets updated. But it does pass the tests.

Further work may be to implement `TdAgentGem` as a custom resource rather than an LWRP, so that we could make it inherit from `GemPackage` directly, which would remove the need to duplicate the API.

[1]: https://github.com/chef/chef/commit/312253ebfd88ac57b8433c2f859690068fe7cb14
[2]: https://gist.github.com/eightbitraptor/0099e6cfb6a54333951b