### PR TITLE
added support for debian for td-agent 2.x

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -19,6 +19,9 @@ platforms:
   - name: centos-6.6
     driver_config:
       image: centos:centos6
+  - name: debian-7.8
+    driver_config:
+      image: debian:7.8
 
 suites:
   - name: default

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -54,7 +54,7 @@ when "debian"
       end
     else
       # version 2.x or later
-      "http://packages.treasuredata.com/#{major}/ubuntu/#{dist}/"
+      "http://packages.treasuredata.com/#{major}/#{node['platform']}/#{dist}/"
     end
 
   apt_repository "treasure-data" do


### PR DESCRIPTION
I added support for debian wheezy (should work with squeeze as well) for td-agent 2.x There is no 1.x repository anymore, so this won't work, but I tested it with 2.x and it worked fine. 