### PR TITLE
A fix to treasure-data yum_repository on Amazon Linux platform

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -70,7 +70,11 @@ when "rhel"
       "http://packages.treasuredata.com/redhat/$basearch"
     else
       # version 2.x or later
-      "http://packages.treasuredata.com/2/redhat/$releasever/$basearch"
+      if node['platform'] == 'amazon'
+        "http://packages.treasuredata.com/2/redhat/6/$basearch"
+      else
+        'http://packages.treasuredata.com/2/redhat/$releasever/$basearch'
+      end
     end
 
   yum_repository "treasure-data" do


### PR DESCRIPTION
Current cookbook results in error when adding Yum repository config on AWS Amazon Linux platform:

	================================================================================
	Error executing action `add` on resource 'yum_repository[treasure-data]'
	================================================================================


	Mixlib::ShellOut::ShellCommandFailed
	------------------------------------
	execute[yum-makecache-treasure-data] (/var/chef/cache/cookbooks/yum/providers/repository.rb line 61) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '1'
	---- Begin output of yum -q -y makecache --disablerepo=* --enablerepo=treasure-data ----
	STDOUT:
	STDERR: http://packages.treasuredata.com/2/redhat/2014.09/x86_64/repodata/repomd.xml: [Errno 14] PYCURL ERROR 22 - "The requested URL returned error: 404 Not Found"
	Trying other mirror.

This change adds a condition to fix invalid repository URL.