### PR TITLE
Use @include directive when use v2

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -83,9 +83,13 @@ end
 
 reload_action = (reload_available?) ? :reload : :restart
 
+major_version = major
 template "/etc/td-agent/td-agent.conf" do
   mode "0644"
   source "td-agent.conf.erb"
+  variables(
+    :major_version => major_version
+  )
   notifies reload_action, "service[td-agent]"
 end
 

--- a/templates/default/td-agent.conf.erb
+++ b/templates/default/td-agent.conf.erb
@@ -1,5 +1,9 @@
 <% if node['td_agent']['includes'] %>
+<% if @major_version.to_i < 2 %>
 include conf.d/*.conf
+<% else %>
+@include conf.d/*.conf
+<% end %>
 <% end %>
 <% if node['td_agent']['default_config'] %>
 ####


### PR DESCRIPTION
If node["td_agent"]["includes"] == true

- v1 td-agent.conf `include`
- v2 td-agent.conf `@include`
  - to avoid warn log in td-agent.log