### PR TITLE
Specify arch='amd64' to the apt_repository resource, fixing #53.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,6 +10,7 @@ default["td_agent"]["default_config"] = true
 default["td_agent"]["in_http"]["enable_api"] = true
 default["td_agent"]["version"] = "2.2.0"
 default["td_agent"]["pinning_version"] = false
+default["td_agent"]["apt_arch"] = 'amd64'
 default["td_agent"]["in_forward"] = {
   port: 24224,
   bind: '0.0.0.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -60,6 +60,7 @@ when "debian"
 
   apt_repository "treasure-data" do
     uri source
+    arch node["td_agent"]["apt_arch"]
     distribution dist
     components ["contrib"]
     key "https://packages.treasuredata.com/GPG-KEY-td-agent"


### PR DESCRIPTION
A very simple PR which should fix issue #53.

As explained by @rmoriz in the original issue, default installations of ubuntu 14.04 are multiarch (with `amd64` the native architecture and `i386` the foreign architecture); adding the td-agent repository without specifying the arch breaks `apt-get update` because apt expects the repository to support both arches (amd64 and i386) while the repository only provides amd64 packages (as can be seen here: https://td-agent-package-browser.herokuapp.com/2/ubuntu/trusty/pool/contrib/t/td-agent )

The solution is simply to declare the td-agent repository as only supporting the `amd64` architecture.