### PR TITLE
fixed rhel repo (add necessary backslash)

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -69,10 +69,10 @@ when "debian"
 when "rhel"
   source =
     if major.nil? || major == '1'
-      "http://packages.treasuredata.com/redhat/$basearch"
+      "http://packages.treasuredata.com/redhat/\\$basearch"
     else
       # version 2.x or later
-      "http://packages.treasuredata.com/2/redhat/$releasever/$basearch"
+      "http://packages.treasuredata.com/2/redhat/\\$releasever/\\$basearch"
     end
 
   yum_repository "treasure-data" do


### PR DESCRIPTION
Rpm baseurl for rhel platform is different from official one.

Incorrect (this recipe)
```
baseurl=http://packages.treasuredata.com/2/redhat/$releasever/$basearch
```

Correct (Official)
```
baseurl=http://packages.treasuredata.com/2/redhat/\$releasever/\$basearch
```
See official: http://docs.fluentd.org/articles/install-by-rpm


due to this issue recipe does not work on Amazon Linux