### PR TITLE
Allow a wrapper cookbook to specify a local template, delay reloading the main process

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,6 +7,7 @@ default["td_agent"]["gid"] = nil
 
 default["td_agent"]["includes"] = false
 default["td_agent"]["default_config"] = true
+default["td_agent"]["template_cookbook"] = 'td-agent'
 default["td_agent"]["in_http"]["enable_api"] = true
 default["td_agent"]["version"] = "2.2.0"
 default["td_agent"]["pinning_version"] = false

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -79,6 +79,7 @@ when "rhel"
     url source
     gpgkey "https://packages.treasuredata.com/GPG-KEY-td-agent"
     action :add
+    not_if { node['platform'] == 'amazon' }
   end
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -89,7 +89,7 @@ template "/etc/td-agent/td-agent.conf" do
   mode "0644"
   cookbook node['td_agent']['template_cookbook']
   source "td-agent.conf.erb"
-  notifies reload_action, "service[td-agent]"
+  notifies reload_action, "service[td-agent]", :delayed
 end
 
 directory "/etc/td-agent/conf.d" do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -86,6 +86,7 @@ reload_action = (reload_available?) ? :reload : :restart
 
 template "/etc/td-agent/td-agent.conf" do
   mode "0644"
+  cookbook node['td_agent']['template_cookbook']
   source "td-agent.conf.erb"
   notifies reload_action, "service[td-agent]"
 end


### PR DESCRIPTION
This change allows a wrapper cookbook to specify a local template for their own custom config.