### PR TITLE
Amazon Linux support.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -72,7 +72,13 @@ when "rhel"
       "http://packages.treasuredata.com/redhat/$basearch"
     else
       # version 2.x or later
-      "http://packages.treasuredata.com/2/redhat/$releasever/$basearch"
+      case node['platform']
+      when 'amazon'
+        # amazon linux is a fork of CentOS 6, doesn't have systemd used in RHEL7 package
+        "http://packages.treasuredata.com/2/redhat/6/$basearch"
+      else
+        "http://packages.treasuredata.com/2/redhat/$releasever/$basearch"
+      end
     end
 
   yum_repository "treasure-data" do


### PR DESCRIPTION
Maps amazon linux to RHEL6 repo as the RHEL7 rpm won't work.