### PR TITLE
Add `yum_amazon_releasever` to override `$releasever` of yum source URL

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,3 +20,4 @@ default["td_agent"]["in_http"] = {
   port: 8888,
   bind: '0.0.0.0'
 }
+default["td_agent"]["yum_amazon_releasever"] = "$releasever"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -74,6 +74,9 @@ when "rhel"
     else
       # version 2.x or later
       if platform == "amazon"
+        if node["td_agent"]["yum_amazon_releasever"] != "$releasever"
+          Chef::Log.warn("Treasure Data doesn't guarantee td-agent works on older Amazon Linux releases. td-agent could be used on such environment at your own risk.")
+        end
         "http://packages.treasuredata.com/2/redhat/#{node["td_agent"]["yum_amazon_releasever"]}/$basearch"
       else
         "http://packages.treasuredata.com/2/redhat/$releasever/$basearch"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -67,12 +67,17 @@ when "debian"
     action :add
   end
 when "rhel"
+  platform = node["platform"]
   source =
     if major.nil? || major == '1'
       "http://packages.treasuredata.com/redhat/$basearch"
     else
       # version 2.x or later
-      "http://packages.treasuredata.com/2/redhat/$releasever/$basearch"
+      if platform == "amazon"
+        "http://packages.treasuredata.com/2/redhat/#{node["td_agent"]["yum_amazon_releasever"]}/$basearch"
+      else
+        "http://packages.treasuredata.com/2/redhat/$releasever/$basearch"
+      end
     end
 
   yum_repository "treasure-data" do


### PR DESCRIPTION
Allow older Amazon Linux users to override `$releasever` at their own risk. I think this can be a workaround for situation like #60.

@repeatedly how do you think?