### PR TITLE
Make match definition file readable.

### DIFF
--- a/providers/match.rb
+++ b/providers/match.rb
@@ -74,5 +74,6 @@ def params_to_text(params)
       body += "#{k} #{v}\n"
     end
   end
-  body
+  indent = '  '
+  body.each_line.map{|line| "#{indent}#{line}"}.join
 end

--- a/templates/default/match.conf.erb
+++ b/templates/default/match.conf.erb
@@ -3,5 +3,5 @@
 
 <match <%= @tag %>>
   type <%= @type %>
-  <%= @params %>
+<%= @params %>
 </match>


### PR DESCRIPTION
Insert indent space to match provider.

Example.
```
<match webserver.*>
  type copy
  <store>
type gelf
host 127.0.0.1
port 12201
flush_interval 5s
</store>
<store>
type stdout
</store>

</match>
```

to

```
<match webserver.*>
  type copy
  <store>
    type gelf
    host 127.0.0.1
    port 12201
    flush_interval 5s
  </store>
  <store>
    type stdout
  </store>

</match>
```
