### PR TITLE
Support for multithreading via multiprocess plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ If `pinning_version` is true, then `version`'s td-agent will be installed. The d
 
 In this case, you should set the full version in `node[:td_agent][:version]`.
 
+## multiprocess
+
+Installs the multiprocess plugin and uses round-robin to forward to child instances, allowing multithreading. Additional configuration files are automatically created based on the number of cores found.
+
+```ruby
+node["td_agent"]["multiprocess"] = true
+```
+
 ### Limitation
 
 `pinning_version` and `version` attributes are now available for `rpm` packages.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,6 +10,7 @@ default["td_agent"]["default_config"] = true
 default["td_agent"]["in_http"]["enable_api"] = true
 default["td_agent"]["version"] = "2.2.0"
 default["td_agent"]["pinning_version"] = false
+default["td_agent"]["multiprocess"] = false
 default["td_agent"]["apt_arch"] = 'amd64'
 default["td_agent"]["in_forward"] = {
   port: 24224,

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -84,6 +84,25 @@ end
 
 reload_action = (reload_available?) ? :reload : :restart
 
+if node["td_agent"]["multiprocess"]
+  (1..node["cpu"]["total"]).each do |i|
+    padded = sprintf '%02d', i
+    template "/etc/td-agent/td-agent-child#{padded}.conf" do
+      mode "0644"
+      source "td-agent-child-master.conf.erb"
+      variables({
+        :portoffset => i
+      })
+    end
+  end
+
+  %w{ fluent-plugin-multiprocess serverengine }.each do |gem|
+    td_agent_gem "#{gem}" do
+      plugin false
+    end
+  end
+end
+
 template "/etc/td-agent/td-agent.conf" do
   mode "0644"
   source "td-agent.conf.erb"

--- a/templates/default/td-agent-child-master.conf.erb
+++ b/templates/default/td-agent-child-master.conf.erb
@@ -1,0 +1,7 @@
+<source>
+   type forward
+   port <%= 24224 + @portoffset %>
+   bind 127.0.0.1
+</source>
+
+include match.conf

--- a/templates/default/td-agent.conf.erb
+++ b/templates/default/td-agent.conf.erb
@@ -1,6 +1,34 @@
 <% if node['td_agent']['includes'] %>
 include conf.d/*.conf
 <% end %>
+<% if node['td_agent']['multiprocess'] %>
+<source>
+  type multiprocess
+     <% (1..node["cpu"]["total"]).each do |i|
+     padded = sprintf '%02d', i %>
+     <process>
+          cmdline -c /etc/td-agent/td-agent-child<%= padded %>.conf --group td-agent --log /var/log/td-agent/td-agent-child<%= padded %>.log --daemon /var/run/td-agent/td-agent-child<%= padded %>.pid
+     </process>
+     <% end -%>
+</source>
+
+<match *>
+        type roundrobin
+        <% port=24224
+        (1..node["cpu"]["total"]).each do |i| %>
+
+     <store>
+            type forward
+            <server>
+               name fluentd-child<%= sprintf '%02d', i %>
+               host 127.0.0.1
+               port <%= port + i %>
+            </server>
+     </store>
+        <% end -%>
+
+</match>
+<% end %>
 <% if node['td_agent']['default_config'] %>
 ####
 ## Output descriptions:


### PR DESCRIPTION
Child cfg files are created based on the number of cores found.
roundrobin is used to send data to each child process.