### PR TITLE
Make system user & group as attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,6 +5,9 @@ default["td_agent"]["plugins"] = []
 default["td_agent"]["uid"] = nil
 default["td_agent"]["gid"] = nil
 
+default["td_agent"]["user"] = 'td-agent'
+default["td_agent"]["group"] = 'td-agent'
+
 default["td_agent"]["includes"] = false
 default["td_agent"]["default_config"] = true
 default["td_agent"]["template_cookbook"] = 'td-agent'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,15 +28,15 @@ user 'td-agent' do
 end
 
 directory '/var/run/td-agent/' do
-  owner  'td-agent'
-  group  'td-agent'
+  owner  node["td_agent"]["user"]
+  group  node["td_agent"]["group"]
   mode   '0755'
   action :create
 end
 
 directory '/etc/td-agent/' do
-  owner  'td-agent'
-  group  'td-agent'
+  owner  node["td_agent"]["user"]
+  group  node["td_agent"]["group"]
   mode   '0755'
   action :create
 end
@@ -94,6 +94,8 @@ reload_action = (reload_available?) ? :reload : :restart
 
 major_version = major
 template "/etc/td-agent/td-agent.conf" do
+  owner  node["td_agent"]["user"]
+  group  node["td_agent"]["group"]
   mode "0644"
   cookbook node['td_agent']['template_cookbook']
   source "td-agent.conf.erb"
@@ -104,6 +106,8 @@ template "/etc/td-agent/td-agent.conf" do
 end
 
 directory "/etc/td-agent/conf.d" do
+  owner node["td_agent"]["user"]
+  group node["td_agent"]["group"]
   mode "0755"
   only_if { node["td_agent"]["includes"] }
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -8,18 +8,18 @@
 Chef::Recipe.send(:include, TdAgent::Version)
 Chef::Provider.send(:include, TdAgent::Version)
 
-group 'td-agent' do
-  group_name 'td-agent'
+group node["td_agent"]["group"] do
+  group_name node["td_agent"]["group"]
   gid node["td_agent"]["gid"] if node["td_agent"]["gid"]
   system true
   action     [:create]
 end
 
-user 'td-agent' do
+user node["td_agent"]["user"] do
   comment  'td-agent'
   uid node["td_agent"]["uid"] if node["td_agent"]["uid"]
   system true
-  group    'td-agent'
+  group    node["td_agent"]["group"]
   home     '/var/run/td-agent'
   shell    '/bin/false'
   password nil
@@ -141,3 +141,7 @@ service "td-agent" do
   supports :restart => true, :reload => (reload_action == :reload), :status => true
   action [ :enable, :start ]
 end
+
+
+##### /var/log/td-agent
+##### /var/log/td-agent/buffer


### PR DESCRIPTION
Currently, the cookbook has the user and group 'td-agent' as a hard-coded value in a couple of resource blocks. This change refactors the constant values and defines the user & group as attributes instead.

This will help us with our situation described in issue #78 