### PR TITLE
Use custom template source for source provider

### DIFF
--- a/providers/source.rb
+++ b/providers/source.rb
@@ -32,7 +32,7 @@ action :create do
     variables(type: new_resource.type,
               params: new_resource.params,
               tag: new_resource.tag)
-    cookbook 'td-agent'
+    cookbook new_resource.template_source
     notifies reload_action, 'service[td-agent]'
   end
 

--- a/resources/source.rb
+++ b/resources/source.rb
@@ -26,3 +26,4 @@ attribute :source_name, :kind_of => String, :name_attribute => true, :required =
 attribute :type, :kind_of => String, :required => true
 attribute :tag, :kind_of => String
 attribute :params, :kind_of => Hash
+attribute :template_source, :kind_of => String, default: 'td-agent'


### PR DESCRIPTION
That feature is required to be able to use custom plugins like:
https://github.com/repeatedly/fluent-plugin-multi-format-parser