### PR TITLE
Add Fedora support.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -66,6 +66,22 @@ when "debian"
     key "https://packages.treasuredata.com/GPG-KEY-td-agent"
     action :add
   end
+when "fedora"
+  platform = node["platform"]
+  source =
+    if major.nil? || major == '1'
+      "http://packages.treasuredata.com/redhat/$basearch"
+    else
+      # version 2.x or later
+        "http://packages.treasuredata.com/2/redhat/7/$basearch"
+    end
+
+  yum_repository "treasure-data" do
+    description "TreasureData"
+    url source
+    gpgkey "https://packages.treasuredata.com/GPG-KEY-td-agent"
+    action :add
+  end
 when "rhel"
   platform = node["platform"]
   source =
@@ -84,6 +100,7 @@ when "rhel"
     end
 
   yum_repository "treasure-data" do
+    description "TreasureData"
     url source
     gpgkey "https://packages.treasuredata.com/GPG-KEY-td-agent"
     action :add


### PR DESCRIPTION
This PR adds in support for using the CentOS 7 repo for Fedora. I have tested this on Fedora 24. 

Since Fedora is considered it's own platform family per https://github.com/chef/ohai/blob/master/lib/ohai/plugins/linux/platform.rb#L191-L194 I added in a case to handle creating the repo file using the CentOS 7 repo. 

It would be super sweet if TD created an official Fedora repository. If you folks don't want to officially support Fedora and you can point me at the current CentOS 7 spec file, I can make one for Fedora and throw it on https://copr.fedorainfracloud.org/
