### PR TITLE
Add package retry

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -113,6 +113,8 @@ directory "/etc/td-agent/conf.d" do
 end
 
 package "td-agent" do
+  retries 3
+  retry_delay 10
   if node["td_agent"]["pinning_version"]
     action :install
     version node["td_agent"]["version"]


### PR DESCRIPTION
On occasion the package install fails due to the yum mirror being unavailable:

```shell
Aug 20 03:21:38 host-007e8a9e6e94d4737 host-configure[345]: Error executing action `install` on resource 'yum_package[td-agent]'
Aug 20 03:21:38 host-007e8a9e6e94d4737 host-configure[345]: yum-deprecated -d0 -e0 -y install td-agent-2.3.2-0.el7 returned 1:
Aug 20 03:21:38 host-007e8a9e6e94d4737 host-configure[345]:   td-agent-2.3.2-0.el7.x86_64: [Errno 256] No more mirrors to try.
```

so this PR adds a retry that tries up to 3 times with a 10 second delay.

