### PR TITLE
Specify baseurl instead of url for yum_repository

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -12,7 +12,7 @@ recipe           "td-agent", "td-agent configuration"
 end
 
 depends 'apt'
-depends 'yum'
+depends 'yum', '~> 3.0'
 
 attribute "td_agent/api_key",
   :display_name => "Treasure Data ApiKey",

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -78,7 +78,7 @@ when "fedora"
 
   yum_repository "treasure-data" do
     description "TreasureData"
-    url source
+    baseurl source
     gpgkey "https://packages.treasuredata.com/GPG-KEY-td-agent"
     action :add
   end
@@ -101,7 +101,7 @@ when "rhel"
 
   yum_repository "treasure-data" do
     description "TreasureData"
-    url source
+    baseurl source
     gpgkey "https://packages.treasuredata.com/GPG-KEY-td-agent"
     action :add
   end


### PR DESCRIPTION
We recently ran into this chef error thrown from the td-agent cookbook:

```
    amazon-ebs: ================================================================================
    amazon-ebs: Recipe Compile Error in /media/ephemeral0/packer-chef-solo/local-mode-cache/cache/cookbooks/XXX-base/recipes/default.rb
    amazon-ebs: ================================================================================
    amazon-ebs:
    amazon-ebs: NoMethodError
    amazon-ebs: -------------
    amazon-ebs: undefined method `url' for Chef::Resource::YumRepository
    amazon-ebs:
    amazon-ebs: Cookbook Trace:
    amazon-ebs: ---------------
    amazon-ebs: /media/ephemeral0/packer-chef-solo/local-mode-cache/cache/cookbooks/td-agent/recipes/default.rb:87:in `block in from_file'
    amazon-ebs: /media/ephemeral0/packer-chef-solo/local-mode-cache/cache/cookbooks/td-agent/recipes/default.rb:86:in `from_file'
    amazon-ebs: /media/ephemeral0/packer-chef-solo/local-mode-cache/cache/cookbooks/XXX-base/recipes/td-agent.rb:16:in `from_file'
    amazon-ebs: /media/ephemeral0/packer-chef-solo/local-mode-cache/cache/cookbooks/XXX-base/recipes/default.rb:56:in `from_file'
    amazon-ebs:
    amazon-ebs: Relevant File Content:
    amazon-ebs: ----------------------
    amazon-ebs: /media/ephemeral0/packer-chef-solo/local-mode-cache/cache/cookbooks/td-agent/recipes/default.rb:
    amazon-ebs:
    amazon-ebs: 80:          "http://packages.treasuredata.com/2/redhat/#{node["td_agent"]["yum_amazon_releasever"]}/$basearch"
    amazon-ebs: 81:        else
    amazon-ebs: 82:          "http://packages.treasuredata.com/2/redhat/$releasever/$basearch"
    amazon-ebs: 83:        end
    amazon-ebs: 84:      end
    amazon-ebs: 85:
    amazon-ebs: 86:    yum_repository "treasure-data" do
    amazon-ebs: 87>>     url source
    amazon-ebs: 88:      gpgkey "https://packages.treasuredata.com/GPG-KEY-td-agent"
    amazon-ebs: 89:      action :add
    amazon-ebs: 90:    end
    amazon-ebs: 91:  end
    amazon-ebs: 92:
    amazon-ebs: 93:  reload_action = (reload_available?) ? :reload : :restart
    amazon-ebs: 94:
    amazon-ebs: 95:  major_version = major
    amazon-ebs: 96:  template "/etc/td-agent/td-agent.conf" do
    amazon-ebs:
    amazon-ebs: Platform:
    amazon-ebs: ---------
    amazon-ebs: x86_64-linux
```

It looks like the `url` attribute was deprecated by the yum cookbook and `baseurl` should be used instead.

This PR makes that switch and adds a major version lock for the yum cookbook dependency.
