### PR TITLE
Fix deprecation

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,7 +23,7 @@ user node["td_agent"]["user"] do
   home     '/var/run/td-agent'
   shell    '/bin/false'
   password nil
-  supports :manage_home => true
+  manage_home true
   action   [:create, :manage]
 end
 


### PR DESCRIPTION
I used Chef 12.17.44.
The following warning occurred after execution.

```
Deprecated features used!
supports { manage_home: true } on the user resource is deprecated and will be removed in Chef 13, set manage_home true instead at 1 location:
- /tmp/packer-chef-solo/local-mode-cache/cache/cookbooks/td-agent/recipes/default.rb:26:in `block in from_file'
See https://docs.chef.io/deprecations_supports_property.html for further details.
```

`manage_home` property is exists in Chef 11.0.
https://docs.chef.io/release/11-0/resource_user.html
