### PR TITLE
renamed params to parameters to support chef v13

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Notice: If you use some plugins in your sources, you should install it before yo
 | source_name | File name. To its value will be added `.conf`. Defaults to `name`  |
 | type | Type of source. This is name of input plugin. |
 | tag | Tag, what uses in fluentd routing. |
-| params | Parameters of source. Hash. |
+| parameters | Parameters of source. Hash. |
 
 ### Example
 
@@ -177,7 +177,7 @@ This example creates the source with `tail` type and  `syslog` tag which reads f
 td_agent_source 'test_in_tail' do
   type 'tail'
   tag 'syslog'
-  params(format: 'syslog',
+  parameters(format: 'syslog',
          path: '/var/log/messages')
 end
 ```
@@ -202,7 +202,7 @@ Notice: Notice: If you use some plugins in your matches, you should install it b
 | match_name | File name. To its value will be added `.conf`. Defaults to `name`  |
 | type | Type of match. This is name of output plugin. |
 | tag | Tag, what uses in fluentd routing. |
-| params | Parameters of match. Hash. |
+| parameters | Parameters of match. Hash. |
 
 ### Example
 This example creates the match with type `copy` and tag `webserver.*` which sends log data to local graylog2 server.
@@ -211,7 +211,7 @@ This example creates the match with type `copy` and tag `webserver.*` which send
 td_agent_match 'test_gelf_match' do
   type 'copy'
   tag 'webserver.*'
-  params( store: [{ type: 'gelf',
+  parameters( store: [{ type: 'gelf',
                    host: '127.0.0.1',
                    port: 12201,
                    flush_interval: '5s'},
@@ -239,7 +239,7 @@ Notice: Notice: If you use some plugins for your filters, you should install the
 | filter_name | File name. To its value will be added `.conf`. Defaults to `name`  |
 | type | Type of filter. This is name of output plugin. |
 | tag | Tag, what uses in fluentd routing. |
-| params | Parameters of filter. Hash. |
+| parameters | Parameters of filter. Hash. |
 
 ### Example
 This example creates the filter with type `record_transformer` and tag `webserver.*` which adds the `hostname` field with the server's hostname as its value:
@@ -248,7 +248,7 @@ This example creates the filter with type `record_transformer` and tag `webserve
 td_agent_filter 'filter_webserver' do
   type 'record_transformer'
   tag 'webserver.*'
-  params(
+  parameters(
     record: [ { host_param: %q|"#{Socket.gethostname}"| } ]
   )
 end

--- a/providers/filter.rb
+++ b/providers/filter.rb
@@ -30,7 +30,7 @@ action :create do
     group 'root'
     mode '0644'
     variables(type: new_resource.type,
-              params: params_to_text(new_resource.params),
+              parameters: params_to_text(new_resource.parameters),
               tag: new_resource.tag)
     cookbook 'td-agent'
     notifies reload_action, 'service[td-agent]'
@@ -57,9 +57,9 @@ def reload_action
   end
 end
 
-def params_to_text(params)
+def params_to_text(parameters)
   body = ''
-  params.each do |k,v|
+  parameters.each do |k,v|
     if v.is_a?(Hash)
       body += "<#{k}>\n"
       body += params_to_text(v)

--- a/providers/match.rb
+++ b/providers/match.rb
@@ -30,7 +30,7 @@ action :create do
     group 'root'
     mode '0644'
     variables(type: new_resource.type,
-              params: params_to_text(new_resource.params),
+              parameters: params_to_text(new_resource.parameters),
               tag: new_resource.tag)
     cookbook 'td-agent'
     notifies reload_action, 'service[td-agent]'
@@ -57,9 +57,9 @@ def reload_action
   end
 end
 
-def params_to_text(params)
+def params_to_text(parameters)
   body = ''
-  params.each do |k,v|
+  parameters.each do |k,v|
     if v.is_a?(Hash)
       body += "<#{k}>\n"
       body += params_to_text(v)

--- a/providers/source.rb
+++ b/providers/source.rb
@@ -30,7 +30,7 @@ action :create do
     group 'root'
     mode '0644'
     variables(type: new_resource.type,
-              params: new_resource.params,
+              parameters: new_resource.parameters,
               tag: new_resource.tag)
     cookbook new_resource.template_source
     notifies reload_action, 'service[td-agent]'

--- a/resources/filter.rb
+++ b/resources/filter.rb
@@ -25,4 +25,4 @@ default_action :create
 attribute :filter_name, :kind_of => String, :name_attribute => true, :required => true
 attribute :type, :kind_of => String, :required => true
 attribute :tag, :kind_of => String, :required => true
-attribute :params
+attribute :parameters

--- a/resources/match.rb
+++ b/resources/match.rb
@@ -25,4 +25,4 @@ default_action :create
 attribute :match_name, :kind_of => String, :name_attribute => true, :required => true
 attribute :type, :kind_of => String, :required => true
 attribute :tag, :kind_of => String, :required => true
-attribute :params
+attribute :parameters

--- a/resources/source.rb
+++ b/resources/source.rb
@@ -25,5 +25,5 @@ default_action :create
 attribute :source_name, :kind_of => String, :name_attribute => true, :required => true
 attribute :type, :kind_of => String, :required => true
 attribute :tag, :kind_of => String
-attribute :params, :kind_of => Hash
+attribute :parameters, :kind_of => Hash
 attribute :template_source, :kind_of => String, default: 'td-agent'

--- a/templates/default/filter.conf.erb
+++ b/templates/default/filter.conf.erb
@@ -3,5 +3,5 @@
 
 <filter <%= @tag %>>
   type <%= @type %>
-<%= @params -%>
+<%= @parameters -%>
 </filter>

--- a/templates/default/match.conf.erb
+++ b/templates/default/match.conf.erb
@@ -3,5 +3,5 @@
 
 <match <%= @tag %>>
   type <%= @type %>
-<%= @params -%>
+<%= @parameters -%>
 </match>

--- a/templates/default/source.conf.erb
+++ b/templates/default/source.conf.erb
@@ -6,7 +6,7 @@
   <% if @tag %>
   tag <%= @tag %>
   <% end %>
-  <% @params.each do |k,v| %>
+  <% @parameters.each do |k,v| %>
     <% if v.is_a?(Hash) %>
   <%= k %> <%= v.map{ |k,v| "#{k}:#{v}"}.join(',') %>
     <% elsif v.is_a?(Array) %>

--- a/test/fixtures/smoke/recipes/default.rb
+++ b/test/fixtures/smoke/recipes/default.rb
@@ -31,14 +31,14 @@ td_agent_gem 'gelf'
 td_agent_source 'test_in_tail' do
   type 'tail'
   tag 'syslog'
-  params(format: 'syslog',
+  parameters(format: 'syslog',
          path: '/var/log/messages')
 end
 
 td_agent_source 'test_in_tail_nginx' do
   type 'tail'
   tag 'webserver.nginx'
-  params(format: '/^(?<remote>[^ ]*) - (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*) "(?<referer>[^\"]*)" "(?<agent>[^\"]*)" "(?<forwarded_for>[^\"]*)"$/',
+  parameters(format: '/^(?<remote>[^ ]*) - (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*) "(?<referer>[^\"]*)" "(?<agent>[^\"]*)" "(?<forwarded_for>[^\"]*)"$/',
          time_format: '%d/%b/%Y:%H:%M:%S',
          types: { code: 'integer', size: 'integer' },
          path: '/var/log/nginx/access.log')
@@ -47,7 +47,7 @@ end
 td_agent_match 'test_gelf_match' do
   type 'copy'
   tag 'webserver.*'
-  params( store: [{ type: 'gelf',
+  parameters( store: [{ type: 'gelf',
                    host: '127.0.0.1',
                    port: 12201,
                    flush_interval: '5s'},
@@ -57,7 +57,7 @@ end
 td_agent_filter 'test_filter' do
   type 'record_transformer'
   tag 'webserver.*'
-  params(
+  parameters(
     record: [ { host_param: %q|"#{Socket.gethostname}"| } ]
   )
 end


### PR DESCRIPTION
This is a fix to be able to run the cookbook in chef v13

Here is the error output from chef-client v13:
```
================================================================================
Recipe Compile Error in /var/cache/chef/cookbooks/td-agent/resources/filter.rb
================================================================================

ArgumentError
-------------
Property `params` of resource `td_agent_filter` overwrites an existing method.

Cookbook Trace:
---------------
  /var/cache/chef/cookbooks/td-agent/resources/filter.rb:28:in `class_from_file'
```

This is a breaking change in a way, everyone using the provider need to substitute params with parameters.

