### PR TITLE
Fix support for Amazon Linux in install

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -81,7 +81,9 @@ when "fedora"
     gpgkey "https://packages.treasuredata.com/GPG-KEY-td-agent"
     action :add
   end
-when "rhel"
+when "rhel", "amazon"
+  # platform_family of Amazon Linux is judged as amazon in new version of ohai: https://github.com/chef/ohai/pull/971
+
   platform = node["platform"]
   source =
     if major.nil? || major == '1'


### PR DESCRIPTION
Fixed support for Amazon Linux platform family in Chef 13.

## Chef-client version
13.2.20

## Error

```
         * yum_package[td-agent] action upgrade
           * No candidate version available for td-agent
           * No candidate version available for td-agent
           * No candidate version available for td-agent
           * No candidate version available for td-agent
           ================================================================================
           Error executing action `upgrade` on resource 'yum_package[td-agent]'
           ================================================================================

           Chef::Exceptions::Package
           -------------------------
           No candidate version available for td-agent

           Resource Declaration:
           ---------------------
           # In /tmp/kitchen/cache/cookbooks/td-agent/recipes/install.rb

           116: package "td-agent" do
           117:   retries 3
           118:   retry_delay 10
           119:   if node["td_agent"]["pinning_version"]
           120:     action :install
           121:     version node["td_agent"]["version"]
           122:   else
           123:     action :upgrade
           124:   end
           125: end

           Compiled Resource:
           ------------------
           # Declared in /tmp/kitchen/cache/cookbooks/td-agent/recipes/install.rb:116:in `from_file'

           yum_package("td-agent") do
             package_name "td-agent"
             action [:upgrade]
             default_guard_interpreter :default
             declared_type :package
             cookbook_name "td-agent"
             recipe_name "install"
             retries 3
             retry_delay 10
           end

           System Info:
           ------------
           chef_version=13.2.20
           platform=amazon
           platform_version=2017.03
           ruby=ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-linux]
           program_name=chef-client worker: ppid=2410;start=14:20:29;
           executable=/opt/chef/bin/chef-client
```

`platform_family` of Amazon Linux is judged as `amazon` in Chef 13, so this recipe skipped creating yum repository.