### PR TITLE
Adding major version to redhat yum repo

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -72,7 +72,7 @@ when "fedora"
       "http://packages.treasuredata.com/redhat/$basearch"
     else
       # version 2.x or later
-        "http://packages.treasuredata.com/2/redhat/7/$basearch"
+        "http://packages.treasuredata.com/#{major}/redhat/7/$basearch"
     end
 
   yum_repository "treasure-data" do
@@ -92,9 +92,9 @@ when "rhel"
         if node["td_agent"]["yum_amazon_releasever"] != "$releasever"
           Chef::Log.warn("Treasure Data doesn't guarantee td-agent works on older Amazon Linux releases. td-agent could be used on such environment at your own risk.")
         end
-        "http://packages.treasuredata.com/2/redhat/#{node["td_agent"]["yum_amazon_releasever"]}/$basearch"
+        "http://packages.treasuredata.com/#{major}/redhat/#{node["td_agent"]["yum_amazon_releasever"]}/$basearch"
       else
-        "http://packages.treasuredata.com/2/redhat/$releasever/$basearch"
+        "http://packages.treasuredata.com/#{major}/redhat/$releasever/$basearch"
       end
     end
 


### PR DESCRIPTION
I'd like to use `td-agent` version `3` in my environment. Setting `[td-agent][version] = 3`  isn't working for centos. 
I've added the major version in the repo url, similarly to debian platform, and it's installing version 3 now.
