### PR TITLE
Make sure `params` is still available on Chef 12.x

### DIFF
--- a/providers/filter.rb
+++ b/providers/filter.rb
@@ -29,8 +29,18 @@ action :create do
     owner 'root'
     group 'root'
     mode '0644'
+
+    # Workaround for backward compatibility for Chef pre-13 (#99)
+    chef_major_version = ::Chef::VERSION.split(".").first
+    if chef_major_version < 13 and new_resource.respond_to?(:params)
+      ::Chef::Log.warn("chef-td-agent: property `params` has been renamed to `parameters` since `params` is reserved in Chef 13+. The `params` will not be supported anymore with future release of chef-td-agent")
+      parameters = Hash(new_resource.params).merge(Hash(new_resource.parameters))
+    else
+      parameters = new_resource.parameters
+    end
+
     variables(type: new_resource.type,
-              parameters: params_to_text(new_resource.parameters),
+              parameters: params_to_text(parameters),
               tag: new_resource.tag)
     cookbook 'td-agent'
     notifies reload_action, 'service[td-agent]'

--- a/providers/filter.rb
+++ b/providers/filter.rb
@@ -31,7 +31,7 @@ action :create do
     mode '0644'
 
     # Workaround for backward compatibility for Chef pre-13 (#99)
-    chef_major_version = ::Chef::VERSION.split(".").first
+    chef_major_version = ::Chef::VERSION.split(".").first.to_i
     if chef_major_version < 13 and new_resource.respond_to?(:params)
       ::Chef::Log.warn("chef-td-agent: property `params` has been renamed to `parameters` since `params` is reserved in Chef 13+. The `params` will not be supported anymore with future release of chef-td-agent")
       parameters = Hash(new_resource.params).merge(Hash(new_resource.parameters))

--- a/providers/filter.rb
+++ b/providers/filter.rb
@@ -62,8 +62,7 @@ end
 def reload_action
   if reload_available?
     :reload
-  else
-    :restart
+  else :restart
   end
 end
 

--- a/providers/match.rb
+++ b/providers/match.rb
@@ -29,8 +29,18 @@ action :create do
     owner 'root'
     group 'root'
     mode '0644'
+
+    # Workaround for backward compatibility for Chef pre-13 (#99)
+    chef_major_version = ::Chef::VERSION.split(".").first
+    if chef_major_version < 13 and new_resource.respond_to?(:params)
+      ::Chef::Log.warn("chef-td-agent: property `params` has been renamed to `parameters` since `params` is reserved in Chef 13+. The `params` will not be supported anymore with future release of chef-td-agent")
+      parameters = Hash(new_resource.params).merge(Hash(new_resource.parameters))
+    else
+      parameters = new_resource.parameters
+    end
+
     variables(type: new_resource.type,
-              parameters: params_to_text(new_resource.parameters),
+              parameters: params_to_text(parameters),
               tag: new_resource.tag)
     cookbook 'td-agent'
     notifies reload_action, 'service[td-agent]'

--- a/providers/match.rb
+++ b/providers/match.rb
@@ -31,7 +31,7 @@ action :create do
     mode '0644'
 
     # Workaround for backward compatibility for Chef pre-13 (#99)
-    chef_major_version = ::Chef::VERSION.split(".").first
+    chef_major_version = ::Chef::VERSION.split(".").first.to_i
     if chef_major_version < 13 and new_resource.respond_to?(:params)
       ::Chef::Log.warn("chef-td-agent: property `params` has been renamed to `parameters` since `params` is reserved in Chef 13+. The `params` will not be supported anymore with future release of chef-td-agent")
       parameters = Hash(new_resource.params).merge(Hash(new_resource.parameters))

--- a/providers/source.rb
+++ b/providers/source.rb
@@ -31,7 +31,7 @@ action :create do
     mode '0644'
 
     # Workaround for backward compatibility for Chef pre-13 (#99)
-    chef_major_version = ::Chef::VERSION.split(".").first
+    chef_major_version = ::Chef::VERSION.split(".").first.to_i
     if chef_major_version < 13 and new_resource.respond_to?(:params)
       ::Chef::Log.warn("chef-td-agent: property `params` has been renamed to `parameters` since `params` is reserved in Chef 13+. The `params` will not be supported anymore with future release of chef-td-agent")
       parameters = Hash(new_resource.params).merge(Hash(new_resource.parameters))

--- a/providers/source.rb
+++ b/providers/source.rb
@@ -29,8 +29,18 @@ action :create do
     owner 'root'
     group 'root'
     mode '0644'
+
+    # Workaround for backward compatibility for Chef pre-13 (#99)
+    chef_major_version = ::Chef::VERSION.split(".").first
+    if chef_major_version < 13 and new_resource.respond_to?(:params)
+      ::Chef::Log.warn("chef-td-agent: property `params` has been renamed to `parameters` since `params` is reserved in Chef 13+. The `params` will not be supported anymore with future release of chef-td-agent")
+      parameters = Hash(new_resource.params).merge(Hash(new_resource.parameters))
+    else
+      parameters = new_resource.parameters
+    end
+
     variables(type: new_resource.type,
-              parameters: new_resource.parameters,
+              parameters: parameters,
               tag: new_resource.tag)
     cookbook new_resource.template_source
     notifies reload_action, 'service[td-agent]'

--- a/resources/filter.rb
+++ b/resources/filter.rb
@@ -28,7 +28,7 @@ attribute :tag, :kind_of => String, :required => true
 attribute :parameters
 
 # Workaround for backward compatibility for Chef pre-13 (#99)
-chef_major_version = ::Chef::VERSION.split(".").first
+chef_major_version = ::Chef::VERSION.split(".").first.to_i
 if chef_major_version < 13
   attribute :params
 end

--- a/resources/filter.rb
+++ b/resources/filter.rb
@@ -25,10 +25,10 @@ default_action :create
 attribute :filter_name, :kind_of => String, :name_attribute => true, :required => true
 attribute :type, :kind_of => String, :required => true
 attribute :tag, :kind_of => String, :required => true
-attribute :parameters
+attribute :parameters, :default => {}
 
 # Workaround for backward compatibility for Chef pre-13 (#99)
 chef_major_version = ::Chef::VERSION.split(".").first.to_i
 if chef_major_version < 13
-  attribute :params
+  attribute :params, :default => {}
 end

--- a/resources/filter.rb
+++ b/resources/filter.rb
@@ -26,3 +26,9 @@ attribute :filter_name, :kind_of => String, :name_attribute => true, :required =
 attribute :type, :kind_of => String, :required => true
 attribute :tag, :kind_of => String, :required => true
 attribute :parameters
+
+# Workaround for backward compatibility for Chef pre-13 (#99)
+chef_major_version = ::Chef::VERSION.split(".").first
+if chef_major_version < 13
+  attribute :params
+end

--- a/resources/match.rb
+++ b/resources/match.rb
@@ -28,7 +28,7 @@ attribute :tag, :kind_of => String, :required => true
 attribute :parameters
 
 # Workaround for backward compatibility for Chef pre-13 (#99)
-chef_major_version = ::Chef::VERSION.split(".").first
+chef_major_version = ::Chef::VERSION.split(".").first.to_i
 if chef_major_version < 13
   attribute :params
 end

--- a/resources/match.rb
+++ b/resources/match.rb
@@ -26,3 +26,9 @@ attribute :match_name, :kind_of => String, :name_attribute => true, :required =>
 attribute :type, :kind_of => String, :required => true
 attribute :tag, :kind_of => String, :required => true
 attribute :parameters
+
+# Workaround for backward compatibility for Chef pre-13 (#99)
+chef_major_version = ::Chef::VERSION.split(".").first
+if chef_major_version < 13
+  attribute :params
+end

--- a/resources/match.rb
+++ b/resources/match.rb
@@ -25,10 +25,10 @@ default_action :create
 attribute :match_name, :kind_of => String, :name_attribute => true, :required => true
 attribute :type, :kind_of => String, :required => true
 attribute :tag, :kind_of => String, :required => true
-attribute :parameters
+attribute :parameters, :default => {}
 
 # Workaround for backward compatibility for Chef pre-13 (#99)
 chef_major_version = ::Chef::VERSION.split(".").first.to_i
 if chef_major_version < 13
-  attribute :params
+  attribute :params, :default => {}
 end

--- a/resources/source.rb
+++ b/resources/source.rb
@@ -28,7 +28,7 @@ attribute :tag, :kind_of => String
 attribute :parameters, :kind_of => Hash
 
 # Workaround for backward compatibility for Chef pre-13 (#99)
-chef_major_version = ::Chef::VERSION.split(".").first
+chef_major_version = ::Chef::VERSION.split(".").first.to_i
 if chef_major_version < 13
   attribute :params
 end

--- a/resources/source.rb
+++ b/resources/source.rb
@@ -25,12 +25,12 @@ default_action :create
 attribute :source_name, :kind_of => String, :name_attribute => true, :required => true
 attribute :type, :kind_of => String, :required => true
 attribute :tag, :kind_of => String
-attribute :parameters, :kind_of => Hash
+attribute :parameters, :kind_of => Hash, :default => {}
 
 # Workaround for backward compatibility for Chef pre-13 (#99)
 chef_major_version = ::Chef::VERSION.split(".").first.to_i
 if chef_major_version < 13
-  attribute :params
+  attribute :params, :default => {}
 end
 
 attribute :template_source, :kind_of => String, default: 'td-agent'

--- a/resources/source.rb
+++ b/resources/source.rb
@@ -26,4 +26,11 @@ attribute :source_name, :kind_of => String, :name_attribute => true, :required =
 attribute :type, :kind_of => String, :required => true
 attribute :tag, :kind_of => String
 attribute :parameters, :kind_of => Hash
+
+# Workaround for backward compatibility for Chef pre-13 (#99)
+chef_major_version = ::Chef::VERSION.split(".").first
+if chef_major_version < 13
+  attribute :params
+end
+
 attribute :template_source, :kind_of => String, default: 'td-agent'

--- a/test/fixtures/smoke/recipes/default.rb
+++ b/test/fixtures/smoke/recipes/default.rb
@@ -60,29 +60,62 @@ end
 td_agent_source 'test_in_tail_nginx' do
   type 'tail'
   tag 'webserver.nginx'
-  parameters(
-    format: '/^(?<remote>[^ ]*) - (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*) "(?<referer>[^\"]*)" "(?<agent>[^\"]*)" "(?<forwarded_for>[^\"]*)"$/',
-    time_format: '%d/%b/%Y:%H:%M:%S',
-    types: { code: 'integer', size: 'integer' },
-    path: '/tmp/access.log',
-    pos_file: '/tmp/.access.log.pos',
-  )
+  case ::Chef::VERSION
+  when /\A12\./
+    params(
+      format: '/^(?<remote>[^ ]*) - (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*) "(?<referer>[^\"]*)" "(?<agent>[^\"]*)" "(?<forwarded_for>[^\"]*)"$/',
+      time_format: '%d/%b/%Y:%H:%M:%S',
+      types: { code: 'integer', size: 'integer' },
+      path: '/tmp/access.log',
+      pos_file: '/tmp/.access.log.pos',
+    )
+  else
+    parameters(
+      format: '/^(?<remote>[^ ]*) - (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*) "(?<referer>[^\"]*)" "(?<agent>[^\"]*)" "(?<forwarded_for>[^\"]*)"$/',
+      time_format: '%d/%b/%Y:%H:%M:%S',
+      types: { code: 'integer', size: 'integer' },
+      path: '/tmp/access.log',
+      pos_file: '/tmp/.access.log.pos',
+    )
+  end
 end
 
 td_agent_match 'test_gelf_match' do
   type 'copy'
   tag 'webserver.*'
-  parameters( store: [{ type: 'gelf',
-                   host: '127.0.0.1',
-                   port: 12201,
-                   flush_interval: '5s'},
-                   { type: 'stdout' }])
+  case ::Chef::VERSION
+  when /\A12\./
+    params(
+      store: [
+        {type: 'gelf', host: '127.0.0.1', port: 12201, flush_interval: '5s'},
+        {type: 'stdout'},
+      ]
+    )
+  else
+    parameters(
+      store: [
+        {type: 'gelf', host: '127.0.0.1', port: 12201, flush_interval: '5s'},
+        {type: 'stdout'},
+      ]
+    )
+  end
 end
 
 td_agent_filter 'test_filter' do
   type 'record_transformer'
   tag 'webserver.*'
-  parameters(
-    record: [ { host_param: %q|"#{Socket.gethostname}"| } ]
-  )
+  case ::Chef::VERSION
+  when /\A12\./
+    params(
+      record: [
+        {host_param: %q|"#{Socket.gethostname}"|},
+      ]
+    )
+  else
+    parameters(
+      record: [
+        {host_param: %q|"#{Socket.gethostname}"|},
+      ]
+    )
+  end
 end

--- a/test/fixtures/smoke/recipes/default.rb
+++ b/test/fixtures/smoke/recipes/default.rb
@@ -19,6 +19,8 @@
 # limitations under the License.
 #
 
+chef_major_version = ::Chef::VERSION.split(".").first.to_i
+
 case node["platform_family"]
 when "rhel"
   # workaround to let `/etc/init.d/functions` to NOT use systemctl(8)
@@ -60,8 +62,7 @@ end
 td_agent_source 'test_in_tail_nginx' do
   type 'tail'
   tag 'webserver.nginx'
-  case ::Chef::VERSION
-  when /\A12\./
+  if chef_major_version < 13
     params(
       format: '/^(?<remote>[^ ]*) - (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*) "(?<referer>[^\"]*)" "(?<agent>[^\"]*)" "(?<forwarded_for>[^\"]*)"$/',
       time_format: '%d/%b/%Y:%H:%M:%S',
@@ -83,8 +84,7 @@ end
 td_agent_match 'test_gelf_match' do
   type 'copy'
   tag 'webserver.*'
-  case ::Chef::VERSION
-  when /\A12\./
+  if chef_major_version < 13
     params(
       store: [
         {type: 'gelf', host: '127.0.0.1', port: 12201, flush_interval: '5s'},
@@ -104,8 +104,7 @@ end
 td_agent_filter 'test_filter' do
   type 'record_transformer'
   tag 'webserver.*'
-  case ::Chef::VERSION
-  when /\A12\./
+  if chef_major_version < 13
     params(
       record: [
         {host_param: %q|"#{Socket.gethostname}"|},


### PR DESCRIPTION
Workarounds for incompatible changes of #93 for Chef pre-13.x. This restores the old `params` property on pre-13.x and show some deprecation warnings on the usage.