### PR TITLE
ensure plugins are installed before config file is created and restarted

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -33,10 +33,12 @@ node["td_agent"]["plugins"].each do |plugin|
       %w{action version source options gem_binary}.each do |attr|
         send(attr, plugin_attributes[attr]) if plugin_attributes[attr]
       end
+      notifies :restart, "service[td-agent]", :delayed
     end
   elsif plugin.is_a?(String)
     td_agent_gem plugin do
       plugin true
+      notifies :restart, "service[td-agent]", :delayed
     end
   end
 end


### PR DESCRIPTION
I've adjusted the setup recipe to re-order the installation of the custom plugins and then restart the agent. 
This will resolve a bug where any plugins that are required in the configuration will be present when the agent starts.
I've also changed the script to a restart (instead of a reload) for this same reason, i.e. any new plugins may be ignored after setup is run if the config file is merely reloaded.

should correct issue #75 
