### PR TITLE
We actually don't need sudo(8) to run CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: required
 dist: trusty
 language: ruby
 


### PR DESCRIPTION
Workaround for https://blog.travis-ci.com/2017-12-12-new-trusty-images-q4-launch