### PR TITLE
Support Internal Repos, Unit Testing, @Type, 3x-, and more

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -45,6 +45,14 @@ suites:
       require_chef_omnibus: 12.21.3
     run_list:
       - recipe[smoke::default]
+  - name: 3x-chef12
+    attributes:
+      td_agent:
+        version: 3.1.0
+    driver_config:
+      require_chef_omnibus: 12.21.3
+    run_list:
+      - recipe[smoke::default]
   - name: 2x-chef13
     attributes:
       td_agent:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -61,3 +61,11 @@ suites:
       require_chef_omnibus: 13.2.20
     run_list:
       - recipe[smoke::default]
+  - name: 3x-chef13
+    attributes:
+      td_agent:
+        version: 3.1.0
+    driver_config:
+      require_chef_omnibus: 13.2.20
+    run_list:
+      - recipe[smoke::default]

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,14 @@ env:
     - TEST_INSTANCE=2x-chef13-ubuntu-xenial
     - TEST_INSTANCE=2x-chef13-centos-centos6
     - TEST_INSTANCE=2x-chef13-centos-centos7
+    - TEST_INSTANCE=3x-chef12-ubuntu-trusty
+    - TEST_INSTANCE=3x-chef12-ubuntu-xenial
+    - TEST_INSTANCE=3x-chef12-centos-centos6
+    - TEST_INSTANCE=3x-chef12-centos-centos7
+    - TEST_INSTANCE=3x-chef13-ubuntu-trusty
+    - TEST_INSTANCE=3x-chef13-ubuntu-xenial
+    - TEST_INSTANCE=3x-chef13-centos-centos6
+    - TEST_INSTANCE=3x-chef13-centos-centos7
 
 script:
   - |

--- a/Berksfile
+++ b/Berksfile
@@ -2,8 +2,12 @@ source "https://api.berkshelf.com"
 
 metadata
 
-cookbook "apt"
-cookbook "yum"
+cookbook 'apt'
+cookbook 'yum'
+
+group :development do
+  cookbook 'td-agent-spec', path: './test/fixtures/td-agent-spec'
+end
 
 group :integration do
   cookbook 'smoke', :path => './test/fixtures/smoke'

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 group :development do
   gem 'berkshelf'
+  gem 'chefspec', '~> 7'
   gem 'guard-kitchen'
   gem 'foodcritic'
   gem 'stove'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,10 @@ GEM
       mixlib-log (~> 1.3)
       rack (~> 2.0)
       uuidtools (~> 2.1)
+    chefspec (7.1.1)
+      chef (>= 12.14.89)
+      fauxhai (>= 4, < 6)
+      rspec (~> 3.0)
     cleanroom (1.0.0)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
@@ -90,6 +94,8 @@ GEM
     erubis (2.7.0)
     faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
+    fauxhai (5.6.0)
+      net-ssh
     ffi (1.9.18)
     ffi-yajl (2.3.1)
       libyajl2 (~> 1.2)
@@ -318,6 +324,7 @@ PLATFORMS
 
 DEPENDENCIES
   berkshelf
+  chefspec (~> 7)
   foodcritic
   guard-kitchen
   kitchen-docker
@@ -325,4 +332,4 @@ DEPENDENCIES
   test-kitchen
 
 BUNDLED WITH
-   1.15.3
+   1.16.1

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,4 +24,4 @@ default["td_agent"]["in_http"] = {
   bind: '0.0.0.0'
 }
 default["td_agent"]["yum_amazon_releasever"] = "$releasever"
-default['td_agent']['internal_repository'] = false
+default['td_agent']['skip_repository'] = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,3 +24,4 @@ default["td_agent"]["in_http"] = {
   bind: '0.0.0.0'
 }
 default["td_agent"]["yum_amazon_releasever"] = "$releasever"
+default['td_agent']['internal_repository'] = false

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,0 +1,25 @@
+module TdAgent
+  # A set of helper methods for the td-agent cookbook
+  module Helpers
+    def self.params_to_text(parameters)
+      body = ''
+      parameters.each do |param_key, param_value|
+        if param_value.is_a?(Hash)
+          body += "<#{param_key}>\n"
+          body += params_to_text(param_value)
+          body += "</#{param_key}>\n"
+        elsif param_value.is_a?(Array)
+          param_value.each do |array_value|
+            body += "<#{param_key}>\n"
+            body += params_to_text(array_value)
+            body += "</#{param_key}>\n"
+          end
+        else
+          body += "#{param_key} #{param_value}\n"
+        end
+      end
+      indent = '  '
+      body.each_line.map { |line| "#{indent}#{line}" }.join
+    end
+  end
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,14 +7,13 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "2.6.0"
 recipe           "td-agent", "td-agent configuration"
 
+chef_version     ">= 12" if respond_to?(:chef_version)
+issues_url       "https://github.com/treasure-data/chef-td-agent/issues" if respond_to?(:issues_url)
+source_url       "https://github.com/treasure-data/chef-td-agent" if respond_to?(:source_url)
+
 %w{redhat centos debian ubuntu}.each do |os|
   supports os
 end
 
 depends 'apt'
 depends 'yum'
-
-attribute "td_agent/api_key",
-  :display_name => "Treasure Data ApiKey",
-  :description => "ApiKey for Treasure Data Service",
-  :default => ''

--- a/providers/filter.rb
+++ b/providers/filter.rb
@@ -40,7 +40,7 @@ action :create do
     end
 
     variables(type: new_resource.type,
-              parameters: params_to_text(parameters),
+              parameters: TdAgent::Helpers.params_to_text(parameters),
               tag: new_resource.tag)
     cookbook 'td-agent'
     notifies reload_action, 'service[td-agent]'
@@ -62,27 +62,7 @@ end
 def reload_action
   if reload_available?
     :reload
-  else :restart
+  else 
+    :restart
   end
-end
-
-def params_to_text(parameters)
-  body = ''
-  parameters.each do |k,v|
-    if v.is_a?(Hash)
-      body += "<#{k}>\n"
-      body += params_to_text(v)
-      body += "</#{k}>\n"
-    elsif v.is_a?(Array)
-      v.each do |v|
-        body += "<#{k}>\n"
-        body += params_to_text(v)
-        body += "</#{k}>\n"
-      end
-    else
-      body += "#{k} #{v}\n"
-    end
-  end
-  indent = '  '
-  body.each_line.map{|line| "#{indent}#{line}"}.join
 end

--- a/providers/match.rb
+++ b/providers/match.rb
@@ -40,7 +40,7 @@ action :create do
     end
 
     variables(type: new_resource.type,
-              parameters: params_to_text(parameters),
+              parameters: TdAgent::Helpers.params_to_text(parameters),
               tag: new_resource.tag)
     cookbook 'td-agent'
     notifies reload_action, 'service[td-agent]'
@@ -65,25 +65,4 @@ def reload_action
   else
     :restart
   end
-end
-
-def params_to_text(parameters)
-  body = ''
-  parameters.each do |k,v|
-    if v.is_a?(Hash)
-      body += "<#{k}>\n"
-      body += params_to_text(v)
-      body += "</#{k}>\n"
-    elsif v.is_a?(Array)
-      v.each do |v|
-        body += "<#{k}>\n"
-        body += params_to_text(v)
-        body += "</#{k}>\n"
-      end
-    else
-      body += "#{k} #{v}\n"
-    end
-  end
-  indent = '  '
-  body.each_line.map{|line| "#{indent}#{line}"}.join
 end

--- a/providers/source.rb
+++ b/providers/source.rb
@@ -40,7 +40,7 @@ action :create do
     end
 
     variables(type: new_resource.type,
-              parameters: parameters,
+              parameters: TdAgent::Helpers.params_to_text(parameters),
               tag: new_resource.tag)
     cookbook new_resource.template_source
     notifies reload_action, 'service[td-agent]'

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -64,6 +64,7 @@ when "debian"
     components ["contrib"]
     key "https://packages.treasuredata.com/GPG-KEY-td-agent"
     action :add
+    not_if { node['td_agent']['internal_repository'] }
   end
 when "fedora"
   platform = node["platform"]
@@ -80,6 +81,7 @@ when "fedora"
     url source
     gpgkey "https://packages.treasuredata.com/GPG-KEY-td-agent"
     action :add
+    not_if { node['td_agent']['internal_repository'] }
   end
 when "rhel", "amazon"
   # platform_family of Amazon Linux is judged as amazon in new version of ohai: https://github.com/chef/ohai/pull/971
@@ -105,6 +107,7 @@ when "rhel", "amazon"
     url source
     gpgkey "https://packages.treasuredata.com/GPG-KEY-td-agent"
     action :add
+    not_if { node['td_agent']['internal_repository'] }
   end
 end
 

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -64,7 +64,7 @@ when "debian"
     components ["contrib"]
     key "https://packages.treasuredata.com/GPG-KEY-td-agent"
     action :add
-    not_if { node['td_agent']['internal_repository'] }
+    not_if { node['td_agent']['skip_repository'] }
   end
 when "fedora"
   platform = node["platform"]
@@ -81,7 +81,7 @@ when "fedora"
     url source
     gpgkey "https://packages.treasuredata.com/GPG-KEY-td-agent"
     action :add
-    not_if { node['td_agent']['internal_repository'] }
+    not_if { node['td_agent']['skip_repository'] }
   end
 when "rhel", "amazon"
   # platform_family of Amazon Linux is judged as amazon in new version of ohai: https://github.com/chef/ohai/pull/971
@@ -107,7 +107,7 @@ when "rhel", "amazon"
     url source
     gpgkey "https://packages.treasuredata.com/GPG-KEY-td-agent"
     action :add
-    not_if { node['td_agent']['internal_repository'] }
+    not_if { node['td_agent']['skip_repository'] }
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,36 @@
+require 'chefspec'
+require 'chefspec/berkshelf'
+
+RSpec.configure do |config|
+  config.file_cache_path = '/var/chef/cache'
+  config.log_level = :warn
+  config.color = true
+  config.formatter = :documentation
+end
+
+shared_context 'converged recipe' do
+  let(:chef_run) do
+    runner = ChefSpec::SoloRunner.new(platform) do |node|
+      node_attributes.each do |k, v|
+        node.default[k] = v
+      end
+    end
+    runner.converge(described_recipe)
+  end
+
+  let(:platform) do
+    {}
+  end
+
+  let(:node_attributes) do
+    {}
+  end
+
+  let(:node) do
+    chef_run.node
+  end
+
+  def attribute(name)
+    node[described_cookbook][name]
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,9 @@ shared_context 'converged recipe' do
   let(:chef_run) do
     runner = ChefSpec::SoloRunner.new(platform) do |node|
       node_attributes.each do |k, v|
-        node.default[k] = v
+        # Normal is a high enough precedence to override
+        # the cookbook defaults
+        node.normal[k] = v
       end
     end
     runner.converge(described_recipe)

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe 'td-agent::default' do
+  include_context 'converged recipe'
+
+  let(:platform) do
+    { platform: 'ubuntu', version: '14.04' }
+  end
+
+  it 'converges without error' do
+    expect { chef_run }.not_to raise_error
+  end
+
+  it 'creates td-agent.conf' do
+    expect(chef_run).to create_template('/etc/td-agent/td-agent.conf')
+  end
+  
+  it 'starts and enables the td-agent service' do
+    expect(chef_run).to start_service('td-agent')
+    expect(chef_run).to enable_service('td-agent')
+  end
+end

--- a/spec/unit/recipes/install_spec.rb
+++ b/spec/unit/recipes/install_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe 'td-agent::install' do
+  include_context 'converged recipe'
+
+  let(:platform) do
+    { platform: 'ubuntu', version: '14.04' }
+  end
+  
+  let(:node_attributes) do
+    {
+      'td_agent' => {
+        'internal_repository' => true,
+        'pinning_version' => true,
+        'version' => '3.1.0'
+      }
+    }
+  end
+
+  it 'converges without error' do
+    expect { chef_run }.not_to raise_error
+  end
+end

--- a/spec/unit/recipes/install_spec.rb
+++ b/spec/unit/recipes/install_spec.rb
@@ -10,8 +10,12 @@ describe 'td-agent::install' do
   let(:node_attributes) do
     {
       'td_agent' => {
-        'skip_repository' => true,
+        'group' => 'td-agent',
+        'gid' => 3000,
         'pinning_version' => true,
+        'skip_repository' => true,
+        'user' => 'td-agent',
+        'uid' => 2000,
         'version' => '3.1.0'
       }
     }
@@ -19,5 +23,24 @@ describe 'td-agent::install' do
 
   it 'converges without error' do
     expect { chef_run }.not_to raise_error
+  end
+
+  it 'creates the td-agent group' do
+    expect(chef_run).to create_group('td-agent')
+      .with(gid: 3000)
+  end
+
+  it 'creates the td-agent user' do
+    expect(chef_run).to create_user('td-agent')
+      .with(uid: 2000)
+  end
+
+  it 'creates td-agent configuration directory' do
+    expect(chef_run).to create_directory('/etc/td-agent/')
+      .with(owner: 'td-agent', group: 'td-agent')
+  end
+
+  it 'creates td-agent runtime directory' do
+    expect(chef_run).to create_directory('/var/run/td-agent/')
   end
 end

--- a/spec/unit/recipes/install_spec.rb
+++ b/spec/unit/recipes/install_spec.rb
@@ -10,7 +10,7 @@ describe 'td-agent::install' do
   let(:node_attributes) do
     {
       'td_agent' => {
-        'internal_repository' => true,
+        'skip_repository' => true,
         'pinning_version' => true,
         'version' => '3.1.0'
       }

--- a/spec/unit/resources/td_agent_filter_spec.rb
+++ b/spec/unit/resources/td_agent_filter_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe 'td-agent-spec::filter' do
+  include_context 'converged recipe'
+
+  let(:platform) do
+    {
+      platform: 'ubuntu',
+      version: '14.04',
+      step_into: %w(td_agent_filter)
+    }
+  end
+
+  let(:node_attributes) do
+    {
+      'td_agent' => {
+        'group' => 'td-agent',
+        'gid' => 3000,
+        'includes' => true,
+        'pinning_version' => true,
+        'skip_repository' => true,
+        'user' => 'td-agent',
+        'uid' => 2000,
+        'version' => '3.1.0'
+      }
+    }
+  end
+
+  it 'converges without error' do
+    expect { chef_run }.not_to raise_error
+  end
+
+  it 'creates unit test filter' do
+    expect(chef_run).to create_td_agent_filter('01_filter')
+  end
+
+  it 'creates the filter config file' do
+    expect(chef_run).to create_template('/etc/td-agent/conf.d/01_filter.conf')
+      .with(variables: {
+        type: 'record_transformer',
+        parameters: "  <record>\n    hostname \"\#{Socket.gethostname}\"\n    tag ${tag}\n  </record>\n",
+        tag: 'test'
+      })
+  end
+end

--- a/spec/unit/resources/td_agent_match_spec.rb
+++ b/spec/unit/resources/td_agent_match_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe 'td-agent-spec::match' do
+  include_context 'converged recipe'
+
+  let(:platform) do
+    {
+      platform: 'ubuntu',
+      version: '14.04',
+      step_into: %w(td_agent_match)
+    }
+  end
+
+  let(:node_attributes) do
+    {
+      'td_agent' => {
+        'group' => 'td-agent',
+        'gid' => 3000,
+        'includes' => true,
+        'pinning_version' => true,
+        'skip_repository' => true,
+        'user' => 'td-agent',
+        'uid' => 2000,
+        'version' => '3.1.0'
+      }
+    }
+  end
+
+  it 'converges without error' do
+    expect { chef_run }.not_to raise_error
+  end
+
+  it 'creates unit test output' do
+    expect(chef_run).to create_td_agent_match('01_out_file')
+  end
+
+  it 'creates the output config file' do
+    expect(chef_run).to create_template('/etc/td-agent/conf.d/01_out_file.conf')
+  end
+end

--- a/spec/unit/resources/td_agent_source_spec.rb
+++ b/spec/unit/resources/td_agent_source_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe 'td-agent-spec::source' do
+  include_context 'converged recipe'
+
+  let(:platform) do
+    {
+      platform: 'ubuntu',
+      version: '14.04',
+      step_into: %w(td_agent_source)
+    }
+  end
+
+  let(:node_attributes) do
+    {
+      'td_agent' => {
+        'group' => 'td-agent',
+        'gid' => 3000,
+        'includes' => true,
+        'pinning_version' => true,
+        'skip_repository' => true,
+        'user' => 'td-agent',
+        'uid' => 2000,
+        'version' => '3.1.0'
+      }
+    }
+  end
+
+  it 'converges without error' do
+    expect { chef_run }.not_to raise_error
+  end
+
+  it 'creates unit test input' do
+    expect(chef_run).to create_td_agent_source('01_input')
+  end
+
+  it 'creates the input config file' do
+    expect(chef_run).to create_template('/etc/td-agent/conf.d/01_input.conf')
+  end
+end

--- a/templates/default/filter.conf.erb
+++ b/templates/default/filter.conf.erb
@@ -2,6 +2,10 @@
 # Do NOT modify this file by hand!
 
 <filter <%= @tag %>>
+  <% if node['td_agent']['version'].to_i < 3 %>
   type <%= @type %>
+  <% else %>
+  @type <%= @type %>
+  <% end %>
 <%= @parameters -%>
 </filter>

--- a/templates/default/match.conf.erb
+++ b/templates/default/match.conf.erb
@@ -2,6 +2,10 @@
 # Do NOT modify this file by hand!
 
 <match <%= @tag %>>
+  <% if node['td_agent']['version'].to_i < 3 %>
   type <%= @type %>
+  <% else %>
+  @type <%= @type %>
+  <% end %>
 <%= @parameters -%>
 </match>

--- a/templates/default/source.conf.erb
+++ b/templates/default/source.conf.erb
@@ -10,13 +10,5 @@
   <% if @tag %>
   tag <%= @tag %>
   <% end %>
-  <% @parameters.each do |k,v| %>
-    <% if v.is_a?(Hash) %>
-  <%= k %> <%= v.map{ |k,v| "#{k}:#{v}"}.join(',') %>
-    <% elsif v.is_a?(Array) %>
-  <%= k %> <%= v.join(',') %>
-    <% else %>
-  <%= k %> <%= v %>
-    <% end %>
-  <% end %>
+  <%= @parameters -%>
 </source>

--- a/templates/default/source.conf.erb
+++ b/templates/default/source.conf.erb
@@ -2,7 +2,11 @@
 # Do NOT modify this file by hand!
 
 <source>
+  <% if node['td_agent']['version'].to_i < 3 %>
   type <%= @type %>
+  <% else %>
+  @type <%= @type %>
+  <% end %>
   <% if @tag %>
   tag <%= @tag %>
   <% end %>

--- a/test/fixtures/smoke/recipes/default.rb
+++ b/test/fixtures/smoke/recipes/default.rb
@@ -47,7 +47,7 @@ td_agent_plugin 'gelf' do
   url 'https://raw.githubusercontent.com/emsearcy/fluent-plugin-gelf/master/lib/fluent/plugin/out_gelf.rb'
 end
 
-td_agent_gem 'gelf'
+td_agent_gem 'fluent-plugin-gelf-hs'
 
 td_agent_source 'test_in_tail' do
   type 'tail'

--- a/test/fixtures/td-agent-spec/Berksfile
+++ b/test/fixtures/td-agent-spec/Berksfile
@@ -1,0 +1,3 @@
+source 'https://supermarket.chef.io'
+
+metadata

--- a/test/fixtures/td-agent-spec/README.md
+++ b/test/fixtures/td-agent-spec/README.md
@@ -1,0 +1,3 @@
+# td_agent_spec
+
+Fixture cookbook to verify the td-agent custom resources

--- a/test/fixtures/td-agent-spec/metadata.rb
+++ b/test/fixtures/td-agent-spec/metadata.rb
@@ -1,0 +1,9 @@
+name 'td-agent-spec'
+maintainer 'Jack Naglieri'
+maintainer_email 'jacknagzdev@gmail.com'
+license 'Apache 2.0'
+description 'Unit test fixture cookbook to verify custom resources within td-agent cookbook'
+long_description 'Unit test fixture cookbook to verify custom resources within td-agent cookbook'
+version '0.1.0'
+
+depends 'td-agent'

--- a/test/fixtures/td-agent-spec/recipes/filter.rb
+++ b/test/fixtures/td-agent-spec/recipes/filter.rb
@@ -1,0 +1,13 @@
+include_recipe 'td-agent::default'
+
+td_agent_filter '01_filter' do
+  action :create
+  type 'record_transformer'
+  tag 'test'
+  parameters(
+    record: {
+      hostname: '"#{Socket.gethostname}"',
+      tag: '${tag}'
+    }
+  )
+end

--- a/test/fixtures/td-agent-spec/recipes/match.rb
+++ b/test/fixtures/td-agent-spec/recipes/match.rb
@@ -1,0 +1,16 @@
+include_recipe 'td-agent::default'
+
+td_agent_match '01_out_file' do
+  action :create
+  type 'file'
+  tag 'my.data'
+  parameters(
+    path: '/var/log/fluent/myapp',
+    compress: 'gzip',
+    buffer: {
+      timekey: '1d',
+      timekey_use_utc: true,
+      timekey_wait: '10m'
+    }
+  )
+end

--- a/test/fixtures/td-agent-spec/recipes/source.rb
+++ b/test/fixtures/td-agent-spec/recipes/source.rb
@@ -1,0 +1,8 @@
+include_recipe 'td-agent::default'
+
+td_agent_source '01_input' do
+  action :create
+  type 'forward'
+  tag 'test'
+  parameters(port: 22222, bind: '0.0.0.0')
+end


### PR DESCRIPTION
to @yyuu 

I have been working with this cookbook and figured I would contribute added features upstream! They are mainly to support the latest `td-agent`, and other changes to support unit and integration testing.

## Changes

* Support `@type` on version 3 of td-agent in templates
* Support installation from internal/non-public repositories (artifactory, etc)
* Add unit testing support
* Modify integration test suite to successfully run
* Fix some Foodcritic offenses

## Testing

Locally with Chefpsec:

```
$ rspec  spec/unit/

td-agent::default
  converges without error
  creates td-agent.conf
  starts and enables the td-agent service

td-agent::install
  converges without error

Finished in 0.87151 seconds (files took 3.09 seconds to load)
4 examples, 0 failures
```

Also ran `kitchen` locally against `3x-ubuntu14.04` successfully. 