### PR TITLE
Avoid caching `/var/lib/docker` to solve Docker's layer caching issue on travis-ci.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ rvm:
 
 cache:
   bundler: true
-  directories:
-    - /var/lib/docker
 
 env:
   matrix:


### PR DESCRIPTION
It looks like CI's failing frequently doe to "layer does not exist". I suspect it was caused due to way too aggressive caching of Docker local files.