### PR TITLE
[recipes] move resources from default into configure recipe

### DIFF
--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -1,0 +1,50 @@
+#
+# Cookbook Name:: td-agent
+# Recipe:: configure
+#
+#
+
+Chef::Recipe.send(:include, TdAgent::Version)
+Chef::Provider.send(:include, TdAgent::Version)
+
+reload_action = (reload_available?) ? :reload : :restart
+
+major_version = major
+template "/etc/td-agent/td-agent.conf" do
+  owner  node["td_agent"]["user"]
+  group  node["td_agent"]["group"]
+  mode "0644"
+  cookbook node['td_agent']['template_cookbook']
+  source "td-agent.conf.erb"
+  variables(
+    :major_version => major_version
+  )
+  notifies reload_action, "service[td-agent]", :delayed
+end
+
+node["td_agent"]["plugins"].each do |plugin|
+  if plugin.is_a?(Hash)
+    plugin_name, plugin_attributes = plugin.first
+    td_agent_gem plugin_name do
+      plugin true
+      %w{action version source options gem_binary}.each do |attr|
+        send(attr, plugin_attributes[attr]) if plugin_attributes[attr]
+      end
+      notifies :restart, "service[td-agent]", :delayed
+    end
+  elsif plugin.is_a?(String)
+    td_agent_gem plugin do
+      plugin true
+      notifies :restart, "service[td-agent]", :delayed
+    end
+  end
+end
+
+service "td-agent" do
+  supports :restart => true, :reload => (reload_action == :reload), :status => true
+  restart_command "/etc/init.d/td-agent restart || /etc/init.d/td-agent start"
+  action [ :enable, :start ]
+end
+
+##### /var/log/td-agent
+##### /var/log/td-agent/buffer

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -5,49 +5,5 @@
 # Copyright 2011, Treasure Data, Inc.
 #
 
-Chef::Recipe.send(:include, TdAgent::Version)
-Chef::Provider.send(:include, TdAgent::Version)
-
 include_recipe 'td-agent::install'
-
-reload_action = (reload_available?) ? :reload : :restart
-
-major_version = major
-template "/etc/td-agent/td-agent.conf" do
-  owner  node["td_agent"]["user"]
-  group  node["td_agent"]["group"]
-  mode "0644"
-  cookbook node['td_agent']['template_cookbook']
-  source "td-agent.conf.erb"
-  variables(
-    :major_version => major_version
-  )
-  notifies reload_action, "service[td-agent]", :delayed
-end
-
-node["td_agent"]["plugins"].each do |plugin|
-  if plugin.is_a?(Hash)
-    plugin_name, plugin_attributes = plugin.first
-    td_agent_gem plugin_name do
-      plugin true
-      %w{action version source options gem_binary}.each do |attr|
-        send(attr, plugin_attributes[attr]) if plugin_attributes[attr]
-      end
-      notifies :restart, "service[td-agent]", :delayed
-    end
-  elsif plugin.is_a?(String)
-    td_agent_gem plugin do
-      plugin true
-      notifies :restart, "service[td-agent]", :delayed
-    end
-  end
-end
-
-service "td-agent" do
-  supports :restart => true, :reload => (reload_action == :reload), :status => true
-  restart_command "/etc/init.d/td-agent restart || /etc/init.d/td-agent start"
-  action [ :enable, :start ]
-end
-
-##### /var/log/td-agent
-##### /var/log/td-agent/buffer
+include_recipe 'td-agent::configure'

--- a/spec/unit/recipes/configure_spec.rb
+++ b/spec/unit/recipes/configure_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe 'td-agent::configure' do
+  include_context 'converged recipe'
+
+  let(:platform) do
+    { platform: 'ubuntu', version: '14.04' }
+  end
+
+  it 'converges without error' do
+    expect { chef_run }.not_to raise_error
+  end
+
+  it 'creates td-agent.conf' do
+    expect(chef_run).to create_template('/etc/td-agent/td-agent.conf')
+  end
+  
+  it 'starts and enables the td-agent service' do
+    expect(chef_run).to start_service('td-agent')
+    expect(chef_run).to enable_service('td-agent')
+  end
+end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -11,12 +11,8 @@ describe 'td-agent::default' do
     expect { chef_run }.not_to raise_error
   end
 
-  it 'creates td-agent.conf' do
-    expect(chef_run).to create_template('/etc/td-agent/td-agent.conf')
-  end
-  
-  it 'starts and enables the td-agent service' do
-    expect(chef_run).to start_service('td-agent')
-    expect(chef_run).to enable_service('td-agent')
+  it 'includes configure and install recipes' do
+    expect(chef_run).to include_recipe('td-agent::install')
+    expect(chef_run).to include_recipe('td-agent::configure')
   end
 end


### PR DESCRIPTION
to @yyuu 
resolves #110 (additional context in the issue)

## Changes

* Split the resources defined in `td-agent::default` into their own recipe (this retains the previous behavior as well)
* Update unit tests
* Bump minor version

## Testing

* Locally with unit tests
* Locally with Kitchen
