### PR TITLE
The backward compatibility code for `params` keyword won't work if `treat_deprecation_warnings_as_errors` is set (fixes #112)

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,6 +6,7 @@ driver:
 provisioner:
   name: chef_zero
   log_level: info
+  deprecations_as_errors: true
 
 platforms:
   - name: ubuntu-trusty

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -21,5 +21,16 @@ module TdAgent
       indent = '  '
       body.each_line.map { |line| "#{indent}#{line}" }.join
     end
+
+    def self.apply_params_kludge?()
+      if ::Chef::Config[:treat_deprecation_warnings_as_errors]
+        # Skip setting up backward compatibility code for `params` (#112)
+        false
+      else
+        # Workaround for backward compatibility for Chef pre-13 (#99)
+        chef_major_version = ::Chef::VERSION.split(".").first.to_i
+        chef_major_version < 13
+      end
+    end
   end
 end

--- a/providers/filter.rb
+++ b/providers/filter.rb
@@ -31,8 +31,7 @@ action :create do
     mode '0644'
 
     # Workaround for backward compatibility for Chef pre-13 (#99)
-    chef_major_version = ::Chef::VERSION.split(".").first.to_i
-    if chef_major_version < 13 and new_resource.respond_to?(:params)
+    if TdAgent::Helpers.apply_params_kludge?
       ::Chef::Log.warn("chef-td-agent: property `params` has been renamed to `parameters` since `params` is reserved in Chef 13+. The `params` will not be supported anymore with future release of chef-td-agent")
       parameters = Hash(new_resource.params).merge(Hash(new_resource.parameters))
     else

--- a/providers/match.rb
+++ b/providers/match.rb
@@ -31,8 +31,7 @@ action :create do
     mode '0644'
 
     # Workaround for backward compatibility for Chef pre-13 (#99)
-    chef_major_version = ::Chef::VERSION.split(".").first.to_i
-    if chef_major_version < 13 and new_resource.respond_to?(:params)
+    if TdAgent::Helpers.apply_params_kludge?
       ::Chef::Log.warn("chef-td-agent: property `params` has been renamed to `parameters` since `params` is reserved in Chef 13+. The `params` will not be supported anymore with future release of chef-td-agent")
       parameters = Hash(new_resource.params).merge(Hash(new_resource.parameters))
     else

--- a/providers/source.rb
+++ b/providers/source.rb
@@ -31,8 +31,7 @@ action :create do
     mode '0644'
 
     # Workaround for backward compatibility for Chef pre-13 (#99)
-    chef_major_version = ::Chef::VERSION.split(".").first.to_i
-    if chef_major_version < 13 and new_resource.respond_to?(:params)
+    if TdAgent::Helpers.apply_params_kludge?
       ::Chef::Log.warn("chef-td-agent: property `params` has been renamed to `parameters` since `params` is reserved in Chef 13+. The `params` will not be supported anymore with future release of chef-td-agent")
       parameters = Hash(new_resource.params).merge(Hash(new_resource.parameters))
     else

--- a/resources/filter.rb
+++ b/resources/filter.rb
@@ -28,7 +28,6 @@ attribute :tag, :kind_of => String, :required => true
 attribute :parameters, :default => {}
 
 # Workaround for backward compatibility for Chef pre-13 (#99)
-chef_major_version = ::Chef::VERSION.split(".").first.to_i
-if chef_major_version < 13
+if TdAgent::Helpers.apply_params_kludge?
   attribute :params, :default => {}
 end

--- a/resources/match.rb
+++ b/resources/match.rb
@@ -28,7 +28,6 @@ attribute :tag, :kind_of => String, :required => true
 attribute :parameters, :default => {}
 
 # Workaround for backward compatibility for Chef pre-13 (#99)
-chef_major_version = ::Chef::VERSION.split(".").first.to_i
-if chef_major_version < 13
+if TdAgent::Helpers.apply_params_kludge?
   attribute :params, :default => {}
 end

--- a/resources/source.rb
+++ b/resources/source.rb
@@ -28,8 +28,7 @@ attribute :tag, :kind_of => String
 attribute :parameters, :kind_of => Hash, :default => {}
 
 # Workaround for backward compatibility for Chef pre-13 (#99)
-chef_major_version = ::Chef::VERSION.split(".").first.to_i
-if chef_major_version < 13
+if TdAgent::Helpers.apply_params_kludge?
   attribute :params, :default => {}
 end
 

--- a/test/fixtures/smoke/recipes/default.rb
+++ b/test/fixtures/smoke/recipes/default.rb
@@ -19,8 +19,6 @@
 # limitations under the License.
 #
 
-chef_major_version = ::Chef::VERSION.split(".").first.to_i
-
 case node["platform_family"]
 when "rhel"
   # workaround to let `/etc/init.d/functions` to NOT use systemctl(8)
@@ -62,7 +60,7 @@ end
 td_agent_source 'test_in_tail_nginx' do
   type 'tail'
   tag 'webserver.nginx'
-  if chef_major_version < 13
+  if TdAgent::Helpers.apply_params_kludge?
     params(
       format: '/^(?<remote>[^ ]*) - (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*) "(?<referer>[^\"]*)" "(?<agent>[^\"]*)" "(?<forwarded_for>[^\"]*)"$/',
       time_format: '%d/%b/%Y:%H:%M:%S',
@@ -84,7 +82,7 @@ end
 td_agent_match 'test_gelf_match' do
   type 'copy'
   tag 'webserver.*'
-  if chef_major_version < 13
+  if TdAgent::Helpers.apply_params_kludge?
     params(
       store: [
         {type: 'gelf', host: '127.0.0.1', port: 12201, flush_interval: '5s'},
@@ -104,7 +102,7 @@ end
 td_agent_filter 'test_filter' do
   type 'record_transformer'
   tag 'webserver.*'
-  if chef_major_version < 13
+  if TdAgent::Helpers.apply_params_kludge?
     params(
       record: [
         {host_param: %q|"#{Socket.gethostname}"|},


### PR DESCRIPTION
It looks like chef client will throw exception if a resource is declaring an attribute named `params` and `treat_deprecation_warnings_as_errors` is set.