### PR TITLE
Add test case for list type parameters

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -9,10 +9,12 @@ module TdAgent
           body += params_to_text(param_value)
           body += "</#{param_key}>\n"
         elsif param_value.is_a?(Array)
-          param_value.each do |array_value|
-            body += "<#{param_key}>\n"
-            body += params_to_text(array_value)
-            body += "</#{param_key}>\n"
+          if param_value.all? { |array_value| array_value.is_a?(Hash) }
+            body += param_value.map { |array_value|
+              "<#{param_key}>\n#{params_to_text(array_value)}</#{param_key}>\n"
+            }.join
+          else
+            body += "#{param_key} [#{param_value.map { |array_value| array_value.to_s.dump }.join(", ")}]\n"
           end
         else
           body += "#{param_key} #{param_value}\n"

--- a/test/fixtures/smoke/recipes/default.rb
+++ b/test/fixtures/smoke/recipes/default.rb
@@ -67,6 +67,7 @@ td_agent_source 'test_in_tail_nginx' do
       types: { code: 'integer', size: 'integer' },
       path: '/tmp/access.log',
       pos_file: '/tmp/.access.log.pos',
+      exclude_path: ["/tmp/access.log.*.gz", "/tmp/access.log.*.bz2"],
     )
   else
     parameters(
@@ -75,6 +76,7 @@ td_agent_source 'test_in_tail_nginx' do
       types: { code: 'integer', size: 'integer' },
       path: '/tmp/access.log',
       pos_file: '/tmp/.access.log.pos',
+      exclude_path: ["/tmp/access.log.*.gz", "/tmp/access.log.*.bz2"],
     )
   end
 end

--- a/test/integration/1x-chef12/bash/spec/localhost/lwrp_spec.rb
+++ b/test/integration/1x-chef12/bash/spec/localhost/lwrp_spec.rb
@@ -33,6 +33,11 @@ end
 describe file('/etc/td-agent/conf.d/test_in_tail_nginx.conf') do
   it { should be_a_file }
   it { should be_mode 644 }
+  its(:content) { should match %r|^\s*type\s+tail$| }
+  its(:content) { should match %r|^\s*tag\s+webserver\.nginx$| }
+  its(:content) { should match %r|^\s*path\s+/tmp/access\.log$| }
+  its(:content) { should match %r|^\s*pos_file\s+/tmp/.access\.log\.pos$| }
+  its(:content) { should match %r|^\s*exclude_path\s+\["/tmp/access\.log\.\*\.gz",\s+"/tmp/access\.log\.\*\.bz2"\]$| }
 end
 
 describe file('/etc/td-agent/conf.d/test_gelf_match.conf') do

--- a/test/integration/2x-chef12/bash/spec/localhost/lwrp_spec.rb
+++ b/test/integration/2x-chef12/bash/spec/localhost/lwrp_spec.rb
@@ -33,6 +33,11 @@ end
 describe file('/etc/td-agent/conf.d/test_in_tail_nginx.conf') do
   it { should be_a_file }
   it { should be_mode 644 }
+  its(:content) { should match %r|^\s*type\s+tail$| }
+  its(:content) { should match %r|^\s*tag\s+webserver\.nginx$| }
+  its(:content) { should match %r|^\s*path\s+/tmp/access\.log$| }
+  its(:content) { should match %r|^\s*pos_file\s+/tmp/.access\.log\.pos$| }
+  its(:content) { should match %r|^\s*exclude_path\s+\["/tmp/access\.log\.\*\.gz",\s+"/tmp/access\.log\.\*\.bz2"\]$| }
 end
 
 describe file('/etc/td-agent/conf.d/test_gelf_match.conf') do

--- a/test/integration/2x-chef13/bash/spec/localhost/lwrp_spec.rb
+++ b/test/integration/2x-chef13/bash/spec/localhost/lwrp_spec.rb
@@ -33,6 +33,11 @@ end
 describe file('/etc/td-agent/conf.d/test_in_tail_nginx.conf') do
   it { should be_a_file }
   it { should be_mode 644 }
+  its(:content) { should match %r|^\s*type\s+tail$| }
+  its(:content) { should match %r|^\s*tag\s+webserver\.nginx$| }
+  its(:content) { should match %r|^\s*path\s+/tmp/access\.log$| }
+  its(:content) { should match %r|^\s*pos_file\s+/tmp/.access\.log\.pos$| }
+  its(:content) { should match %r|^\s*exclude_path\s+\["/tmp/access\.log\.\*\.gz",\s+"/tmp/access\.log\.\*\.bz2"\]$| }
 end
 
 describe file('/etc/td-agent/conf.d/test_gelf_match.conf') do


### PR DESCRIPTION
It looks like after #108, `td_agent_source` starts generating configuration string for list type parameter differently than before.