### PR TITLE
Remove leading space for params

### DIFF
--- a/templates/default/source.conf.erb
+++ b/templates/default/source.conf.erb
@@ -10,5 +10,5 @@
   <% if @tag %>
   tag <%= @tag %>
   <% end %>
-  <%= @parameters -%>
+<%= @parameters -%>
 </source>


### PR DESCRIPTION
to: @yyuu 
size: small

## Change

When parameters are generated (via the library), a leading tab is added.

For `td_agent_source` directives, there's currently an awkward leading tab.  All other ERB templates have this leading tab removed for `@parameters`