### PR TITLE
fixed td-agent version 3 for amazon linux

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,7 +25,3 @@ default["td_agent"]["in_http"] = {
 }
 default["td_agent"]["yum_amazon_releasever"] = "$releasever"
 default['td_agent']['skip_repository'] = false
-default['td_agent']['yum']['amazon'] = {
-  '1' => [ '2017.03', '2017.09', '2018.03'],
-  '2' => [ '2017.12', '2'],
-}

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,3 +25,7 @@ default["td_agent"]["in_http"] = {
 }
 default["td_agent"]["yum_amazon_releasever"] = "$releasever"
 default['td_agent']['skip_repository'] = false
+default['td_agent']['yum']['amazon'] = {
+  '1' => [ '2017.03', '2017.09', '2018.03'],
+  '2' => [ '2017.12', '2'],
+}

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -103,11 +103,7 @@ when "rhel", "amazon"
       end
     when '3'
       if platform == "amazon"
-        if node['kernel']['release'].include?('amzn2')
-          amazon_version = '2'
-        else
-          amazon_version = '1'
-        end
+      amazon_version = node['kernel']['release'].match(/\.amzn([[:digit:]]+)\./)[1]
         "https://packages.treasuredata.com/#{major}/amazon/#{amazon_version}/#{node["td_agent"]["yum_amazon_releasever"]}/$basearch"
       else
         "http://packages.treasuredata.com/#{major}/redhat/$releasever/$basearch"

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -104,12 +104,7 @@ when "rhel", "amazon"
     when '3'
       if platform == "amazon"
         amazon_version = node['platform_version'] == '2' ? '2' : '1'
-        if node['td_agent']['yum']['amazon'][amazon_version].include? node['platform_version']
-          package_version = node['platform_version']
-        else
-          package_version = node['td_agent']['yum']['amazon'][amazon_version].last
-        end
-        "https://packages.treasuredata.com/#{major}/amazon/#{amazon_version}/#{package_version}/$basearch"
+        "https://packages.treasuredata.com/#{major}/amazon/#{amazon_version}/#{node["td_agent"]["yum_amazon_releasever"]}/$basearch"
       else
         "http://packages.treasuredata.com/#{major}/redhat/$releasever/$basearch"
       end

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -103,7 +103,11 @@ when "rhel", "amazon"
       end
     when '3'
       if platform == "amazon"
-        amazon_version = node['platform_version'] == '2' ? '2' : '1'
+        if node['kernel']['release'].include?('amzn2')
+          amazon_version = '2'
+        else
+          amazon_version = '1'
+        end
         "https://packages.treasuredata.com/#{major}/amazon/#{amazon_version}/#{node["td_agent"]["yum_amazon_releasever"]}/$basearch"
       else
         "http://packages.treasuredata.com/#{major}/redhat/$releasever/$basearch"

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -88,9 +88,10 @@ when "rhel", "amazon"
 
   platform = node["platform"]
   source =
-    if major.nil? || major == '1'
+    case major
+    when nil?,'1'
       "http://packages.treasuredata.com/redhat/$basearch"
-    else
+    when '2'
       # version 2.x or later
       if platform == "amazon"
         if node["td_agent"]["yum_amazon_releasever"] != "$releasever"
@@ -100,8 +101,19 @@ when "rhel", "amazon"
       else
         "http://packages.treasuredata.com/#{major}/redhat/$releasever/$basearch"
       end
+    when '3'
+      if platform == "amazon"
+        amazon_version = node['platform_version'] == '2' ? '2' : '1'
+        if node['td_agent']['yum']['amazon'][amazon_version].include? node['platform_version']
+          package_version = node['platform_version']
+        else
+          package_version = node['td_agent']['yum']['amazon'][amazon_version].last
+        end
+        "https://packages.treasuredata.com/#{major}/amazon/#{amazon_version}/#{package_version}/$basearch"
+      else
+        "http://packages.treasuredata.com/#{major}/redhat/$releasever/$basearch"
+      end
     end
-
   yum_repository "treasure-data" do
     description "TreasureData"
     url source


### PR DESCRIPTION
Hi,
I've experienced some issue trying to install td-agent v3 on Amazon linux. I've made a fix that seems to work, but the creation of the repo url is kinda hacky as not all versions of amazon linux have an installer available. Could you take a look? Any feedback for improvement is most welcome!
(tested on serveral versions of Amazon linux 1 and 2)