### PR TITLE
Add new attribute `raw_options` to td_agent_source

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Notice: If you use some plugins in your sources, you should install it before yo
 | type | Type of source. This is name of input plugin. |
 | tag | Tag, what uses in fluentd routing. |
 | parameters | Parameters of source. Hash. |
+| _raw_options | Use attribute value as is. |
 
 ### Example
 
@@ -174,6 +175,20 @@ td_agent_source 'test_in_tail' do
   tag 'syslog'
   parameters(format: 'syslog',
          path: '/var/log/messages')
+end
+```
+
+Use attribute `_raw_options` for attribute that using value such as `Array` or `Hash`. For example when you using [FluentD systemd plugin](https://github.com/reevoo/fluent-plugin-systemd).
+Just add the attribute name as an array item of `_raw_options`
+
+```ruby
+td_agent_source 'tail_journalctl' do
+  type 'systemd'
+  tag 'journalctl'
+  parameters(
+    matches: [{"_SYSTEMD_UNIT": "syslog.service"}]
+  )
+  _raw_options ["matches"]
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ td_agent_source 'tail_journalctl' do
   tag 'journalctl'
   parameters(
     matches: [{"_SYSTEMD_UNIT": "syslog.service"}]
+    read_from_head: true
   )
   _raw_options ["matches"]
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,14 +1,16 @@
 module TdAgent
   # A set of helper methods for the td-agent cookbook
   module Helpers
-    def self.params_to_text(parameters)
+    def self.params_to_text(parameters, raw_options = [])
       body = ''
       parameters.each do |param_key, param_value|
-        if param_value.is_a?(Hash)
+        is_raw_options = raw_options.include?(param_key)
+
+        if param_value.is_a?(Hash) && !is_raw_options
           body += "<#{param_key}>\n"
           body += params_to_text(param_value)
           body += "</#{param_key}>\n"
-        elsif param_value.is_a?(Array)
+        elsif param_value.is_a?(Array) && !is_raw_options
           if param_value.all? { |array_value| array_value.is_a?(Hash) }
             body += param_value.map { |array_value|
               "<#{param_key}>\n#{params_to_text(array_value)}</#{param_key}>\n"

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -19,7 +19,11 @@ module TdAgent
             body += "#{param_key} [#{param_value.map { |array_value| array_value.to_s.dump }.join(", ")}]\n"
           end
         else
-          body += "#{param_key} #{param_value}\n"
+          if param_value.is_a?(Hash) || param_value.is_a?(Array)
+            body += "#{param_key} #{param_value.to_json}\n"
+          else
+            body += "#{param_key} #{param_value}\n"
+          end
         end
       end
       indent = '  '

--- a/providers/source.rb
+++ b/providers/source.rb
@@ -39,7 +39,7 @@ action :create do
     end
 
     variables(type: new_resource.type,
-              parameters: TdAgent::Helpers.params_to_text(parameters),
+              parameters: TdAgent::Helpers.params_to_text(parameters, new_resource._raw_options),
               tag: new_resource.tag)
     cookbook new_resource.template_source
     notifies reload_action, 'service[td-agent]'

--- a/resources/source.rb
+++ b/resources/source.rb
@@ -26,6 +26,7 @@ attribute :source_name, :kind_of => String, :name_attribute => true, :required =
 attribute :type, :kind_of => String, :required => true
 attribute :tag, :kind_of => String
 attribute :parameters, :kind_of => Hash, :default => {}
+attribute :_raw_options, :kind_of => Array, :default => []
 
 # Workaround for backward compatibility for Chef pre-13 (#99)
 if TdAgent::Helpers.apply_params_kludge?

--- a/spec/unit/recipes/configure_spec.rb
+++ b/spec/unit/recipes/configure_spec.rb
@@ -14,7 +14,7 @@ describe 'td-agent::configure' do
   it 'creates td-agent.conf' do
     expect(chef_run).to create_template('/etc/td-agent/td-agent.conf')
   end
-  
+
   it 'starts and enables the td-agent service' do
     expect(chef_run).to start_service('td-agent')
     expect(chef_run).to enable_service('td-agent')

--- a/spec/unit/recipes/install_spec.rb
+++ b/spec/unit/recipes/install_spec.rb
@@ -6,7 +6,7 @@ describe 'td-agent::install' do
   let(:platform) do
     { platform: 'ubuntu', version: '14.04' }
   end
-  
+
   let(:node_attributes) do
     {
       'td_agent' => {


### PR DESCRIPTION
Add capabilities to add an attribute with raw values. This cases will be useful for a plugin like [this](https://github.com/reevoo/fluent-plugin-systemd). The `matches` attribute, need to receive either `[]` or `{}` value.