### PR TITLE
suppress update resource on why-run

### DIFF
--- a/providers/filter.rb
+++ b/providers/filter.rb
@@ -24,7 +24,7 @@ include ::TdAgent::Version
 action :create do
   fail 'You should set the node[:td_agent][:includes] attribute to true to use this resource.' unless node['td_agent']['includes']
 
-  template "/etc/td-agent/conf.d/#{new_resource.filter_name}.conf" do
+  t = template "/etc/td-agent/conf.d/#{new_resource.filter_name}.conf" do
     source 'filter.conf.erb'
     owner 'root'
     group 'root'
@@ -45,17 +45,17 @@ action :create do
     notifies reload_action, 'service[td-agent]'
   end
 
-  new_resource.updated_by_last_action(true)
+  new_resource.updated_by_last_action(true) if t.updated_by_last_action?
 end
 
 action :delete do
-  file "/etc/td-agent/conf.d/#{new_resource.filter_name}.conf" do
+  f = file "/etc/td-agent/conf.d/#{new_resource.filter_name}.conf" do
     action :delete
     only_if { ::File.exist?("/etc/td-agent/conf.d/#{new_resource.filter_name}.conf") }
     notifies reload_action, 'service[td-agent]'
   end
 
-  new_resource.updated_by_last_action(true)
+  new_resource.updated_by_last_action(true) if f.updated_by_last_action?
 end
 
 def reload_action

--- a/providers/match.rb
+++ b/providers/match.rb
@@ -24,7 +24,7 @@ include ::TdAgent::Version
 action :create do
   fail 'You should set the node[:td_agent][:includes] attribute to true to use this resource.' unless node['td_agent']['includes']
 
-  template "/etc/td-agent/conf.d/#{new_resource.match_name}.conf" do
+  t = template "/etc/td-agent/conf.d/#{new_resource.match_name}.conf" do
     source 'match.conf.erb'
     owner 'root'
     group 'root'
@@ -45,17 +45,17 @@ action :create do
     notifies reload_action, 'service[td-agent]'
   end
 
-  new_resource.updated_by_last_action(true)
+  new_resource.updated_by_last_action(true) if t.updated_by_last_action?
 end
 
 action :delete do
-  file "/etc/td-agent/conf.d/#{new_resource.match_name}.conf" do
+  f = file "/etc/td-agent/conf.d/#{new_resource.match_name}.conf" do
     action :delete
     only_if { ::File.exist?("/etc/td-agent/conf.d/#{new_resource.match_name}.conf") }
     notifies reload_action, 'service[td-agent]'
   end
 
-  new_resource.updated_by_last_action(true)
+  new_resource.updated_by_last_action(true) if f.updated_by_last_action?
 end
 
 def reload_action

--- a/providers/plugin.rb
+++ b/providers/plugin.rb
@@ -20,14 +20,16 @@
 #
 
 action :create do
-  directory '/etc/td-agent/plugin' do
+  d = directory '/etc/td-agent/plugin' do
     owner "root"
     group "root"
     mode "0755"
     action :create
   end
 
-  remote_file "/etc/td-agent/plugin/#{new_resource.plugin_name}.rb" do
+  new_resource.updated_by_last_action(true) if d.updated_by_last_action?
+
+  r = remote_file "/etc/td-agent/plugin/#{new_resource.plugin_name}.rb" do
     action :create_if_missing
     owner 'root'
     group 'root'
@@ -36,15 +38,15 @@ action :create do
     notifies :restart, "service[td-agent]"
   end
 
-  new_resource.updated_by_last_action(true)
+  new_resource.updated_by_last_action(true) if r.updated_by_last_action?
 end
 
 action :delete do
-  file "/etc/td-agent/plugin/#{new_resource.plugin_name}.rb" do
+  f = file "/etc/td-agent/plugin/#{new_resource.plugin_name}.rb" do
     action :delete
     only_if { ::File.exist?("/etc/td-agent/plugin/#{new_resource.plugin_name}.rb") }
     notifies :restart, "service[td-agent]"
   end
 
-  new_resource.updated_by_last_action(true)
+  new_resource.updated_by_last_action(true) if f.updated_by_last_action?
 end

--- a/providers/source.rb
+++ b/providers/source.rb
@@ -24,7 +24,7 @@ include ::TdAgent::Version
 action :create do
   fail 'You should set the node[:td_agent][:includes] attribute to true to use this resource.' unless node['td_agent']['includes']
 
-  template "/etc/td-agent/conf.d/#{new_resource.source_name}.conf" do
+  t = template "/etc/td-agent/conf.d/#{new_resource.source_name}.conf" do
     source 'source.conf.erb'
     owner 'root'
     group 'root'
@@ -45,17 +45,17 @@ action :create do
     notifies reload_action, 'service[td-agent]'
   end
 
-  new_resource.updated_by_last_action(true)
+  new_resource.updated_by_last_action(true) if t.updated_by_last_action?
 end
 
 action :delete do
-  file "/etc/td-agent/conf.d/#{new_resource.source_name}.conf" do
+  f = file "/etc/td-agent/conf.d/#{new_resource.source_name}.conf" do
     action :delete
     only_if { ::File.exist?("/etc/td-agent/conf.d/#{new_resource.source_name}.conf") }
     notifies reload_action, 'service[td-agent]'
   end
 
-  new_resource.updated_by_last_action(true)
+  new_resource.updated_by_last_action(true) if f.updated_by_last_action?
 end
 
 def reload_action


### PR DESCRIPTION
On why-run, these providers always detect updated resources.
We regularly execute why-run to ensure idempotency, so want to avoid 'updated_by_last_action' when not neccessary to converge.