### PR TITLE
Feature - support section arguments

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -4,14 +4,15 @@ module TdAgent
     def self.params_to_text(parameters)
       body = ''
       parameters.each do |param_key, param_value|
+        param_key_closing_tag = param_key.to_s.split.first
         if param_value.is_a?(Hash)
           body += "<#{param_key}>\n"
           body += params_to_text(param_value)
-          body += "</#{param_key}>\n"
+          body += "</#{param_key_closing_tag}>\n"
         elsif param_value.is_a?(Array)
           if param_value.all? { |array_value| array_value.is_a?(Hash) }
             body += param_value.map { |array_value|
-              "<#{param_key}>\n#{params_to_text(array_value)}</#{param_key}>\n"
+              "<#{param_key}>\n#{params_to_text(array_value)}</#{param_key_closing_tag}>\n"
             }.join
           else
             body += "#{param_key} [#{param_value.map { |array_value| array_value.to_s.dump }.join(", ")}]\n"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "k@treasure-data.com"
 license          "Apache 2.0"
 description      "Installs/Configures td-agent"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "3.2.1"
+version          "3.3.0"
 recipe           "td-agent", "td-agent configuration"
 
 chef_version     ">= 12" if respond_to?(:chef_version)

--- a/spec/unit/resources/td_agent_match_spec.rb
+++ b/spec/unit/resources/td_agent_match_spec.rb
@@ -32,9 +32,11 @@ describe 'td-agent-spec::match' do
 
   it 'creates unit test output' do
     expect(chef_run).to create_td_agent_match('01_out_file')
+    expect(chef_run).to create_td_agent_match('02_buffer_with_arguments')
   end
 
   it 'creates the output config file' do
     expect(chef_run).to create_template('/etc/td-agent/conf.d/01_out_file.conf')
+    expect(chef_run).to create_template('/etc/td-agent/conf.d/02_buffer_with_arguments.conf')
   end
 end

--- a/test/fixtures/smoke/recipes/default.rb
+++ b/test/fixtures/smoke/recipes/default.rb
@@ -101,6 +101,24 @@ td_agent_match 'test_gelf_match' do
   end
 end
 
+td_agent_match 'test_section_attributes' do
+  type 'null'
+  tag 'null.*'
+  if TdAgent::Helpers.apply_params_kludge?
+    params(
+      'buffer tag, argument1, argument2' => {
+        timekey: '1d'
+      }
+    )
+  else
+    parameters(
+      'buffer tag, argument1, argument2' => {
+        timekey: '1d'
+      }
+    )
+  end
+end
+
 td_agent_filter 'test_filter' do
   type 'record_transformer'
   tag 'webserver.*'

--- a/test/fixtures/td-agent-spec/recipes/match.rb
+++ b/test/fixtures/td-agent-spec/recipes/match.rb
@@ -14,3 +14,14 @@ td_agent_match '01_out_file' do
     }
   )
 end
+
+td_agent_match '02_buffer_with_arguments' do
+  action :create
+  type 'null'
+  tag 'output.null'
+  parameters(
+    'buffer tag, argument1, argument2' => {
+      timekey: '1d'
+    }
+  )
+end

--- a/test/integration/1x-chef12/bash/spec/localhost/lwrp_spec.rb
+++ b/test/integration/1x-chef12/bash/spec/localhost/lwrp_spec.rb
@@ -40,6 +40,14 @@ describe file('/etc/td-agent/conf.d/test_in_tail_nginx.conf') do
 # its(:content) { should match %r|^\s*exclude_path\s+\["/tmp/access\.log\.\*\.gz",\s+"/tmp/access\.log\.\*\.bz2"\]$| }
 end
 
+describe file('/etc/td-agent/conf.d/test_section_attributes.conf') do
+  it { should be_a_file }
+  it { should be_mode 644 }
+  its(:content) { should match %r|^\s*.type null$| }
+  its(:content) { should match %r|^\s*<buffer tag, argument1, argument2>$| }
+  its(:content) { should match %r|^\s*</buffer>$| }
+end
+
 describe file('/etc/td-agent/conf.d/test_gelf_match.conf') do
   it { should be_a_file }
   it { should be_mode 644 }

--- a/test/integration/2x-chef12/bash/spec/localhost/lwrp_spec.rb
+++ b/test/integration/2x-chef12/bash/spec/localhost/lwrp_spec.rb
@@ -40,6 +40,14 @@ describe file('/etc/td-agent/conf.d/test_in_tail_nginx.conf') do
 # its(:content) { should match %r|^\s*exclude_path\s+\["/tmp/access\.log\.\*\.gz",\s+"/tmp/access\.log\.\*\.bz2"\]$| }
 end
 
+describe file('/etc/td-agent/conf.d/test_section_attributes.conf') do
+  it { should be_a_file }
+  it { should be_mode 644 }
+  its(:content) { should match %r|^\s*.type null$| }
+  its(:content) { should match %r|^\s*<buffer tag, argument1, argument2>$| }
+  its(:content) { should match %r|^\s*</buffer>$| }
+end
+
 describe file('/etc/td-agent/conf.d/test_gelf_match.conf') do
   it { should be_a_file }
   it { should be_mode 644 }

--- a/test/integration/2x-chef13/bash/spec/localhost/lwrp_spec.rb
+++ b/test/integration/2x-chef13/bash/spec/localhost/lwrp_spec.rb
@@ -40,6 +40,14 @@ describe file('/etc/td-agent/conf.d/test_in_tail_nginx.conf') do
 # its(:content) { should match %r|^\s*exclude_path\s+\["/tmp/access\.log\.\*\.gz",\s+"/tmp/access\.log\.\*\.bz2"\]$| }
 end
 
+describe file('/etc/td-agent/conf.d/test_section_attributes.conf') do
+  it { should be_a_file }
+  it { should be_mode 644 }
+  its(:content) { should match %r|^\s*.type null$| }
+  its(:content) { should match %r|^\s*<buffer tag, argument1, argument2>$| }
+  its(:content) { should match %r|^\s*</buffer>$| }
+end
+
 describe file('/etc/td-agent/conf.d/test_gelf_match.conf') do
   it { should be_a_file }
   it { should be_mode 644 }


### PR DESCRIPTION
Hi ;)
These changes will let you configure section parameters like `<buffer tag, key1, key2>` (solves #118)
For example: you can use this code to configure ElasticSearch output:

```ruby
td_agent_match 'output_es' do
  type 'elasticsearch'
  tag 'logs.**'
  parameters(
    hosts: 'localhost:9200',
    logstash_prefix: 'fluent-${key1}.${key2}',
    'buffer tag, key1, key2' => {
      timekey: '1d'
    }
  )
end
```
This code will result configuration which will route logs to different indices based on specific keys in message.
```
<match logs.**>
  @type elasticsearch
  index_name elastic.${key1}.${key2}
  <buffer tag, key1, key2>
    timekey 1d
  </buffer>
</match>
```
More information related to section parameters:
- https://docs.fluentd.org/configuration/buffer-section#argument
- https://docs.fluentd.org/configuration/buffer-section#placeholders
- https://github.com/uken/fluent-plugin-elasticsearch#placeholders