### PR TITLE
added condition to service property

### DIFF
--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -42,7 +42,7 @@ end
 
 service "td-agent" do
   supports :restart => true, :reload => (reload_action == :reload), :status => true
-  restart_command "/etc/init.d/td-agent restart || /etc/init.d/td-agent start"
+  restart_command "/etc/init.d/td-agent restart || /etc/init.d/td-agent start" if ::File.exist?('/etc/init.d/td-agent')
   action [ :enable, :start ]
 end
 


### PR DESCRIPTION
td-agent v4 does not ship /etc/init.d/td-agent file for distros that use
systemd (ubuntu focal, for example maybe also others). This makes
chef-client fail to run restart of service, since that was hardcoded to
use init.d script.

This adds a condistion to only set that property if the file actually
esists. If it doesn't exist, then chefs service-mechanism will default
to using whatever is available (systemd in this case) and the chef-run
succeeds to restart the service properly.